### PR TITLE
frameDataIndex を float -> uint32_t へ変更

### DIFF
--- a/Build/Converter/LumpExporter.cpp
+++ b/Build/Converter/LumpExporter.cpp
@@ -995,17 +995,17 @@ private:
 				for(auto frameDataIndexArrayItem : frameDataIndexArrayVec) {
 					auto frameDataVec = frameDataIndexArrayItem->getChildren();
 
-					std::vector<float> ssfbFrameData2;
+					std::vector<uint32_t > ssfbFrameData2;
 					for(auto frameDataItem : frameDataVec) {
 						switch (frameDataItem->type) {
 							case Lump::DataType::S16:
 								ssfbFrameData2.push_back(GETS16(frameDataItem));
 								break;
 							case Lump::DataType::S32:
-								ssfbFrameData2.push_back(GETFLOAT(frameDataItem));
+								ssfbFrameData2.push_back(GETS32(frameDataItem));
 								break;
 							case Lump::DataType::FLOAT:
-								ssfbFrameData2.push_back(GETFLOAT(frameDataItem));
+								ssfbFrameData2.push_back(GETS32(frameDataItem));
 								break;
 							case Lump::DataType::COLOR:
 								{

--- a/Build/Converter/fbs/ssfb.fbs
+++ b/Build/Converter/fbs/ssfb.fbs
@@ -244,7 +244,7 @@ table meshDataIndices {
 }
 
 table frameDataIndex {
-    data : [float];
+    data : [uint];
 }
 
 table userDataInteger {

--- a/Build/Converter/ssfb_generated.h
+++ b/Build/Converter/ssfb_generated.h
@@ -2210,8 +2210,8 @@ struct frameDataIndex FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   enum {
     VT_DATA = 4
   };
-  const flatbuffers::Vector<float> *data() const {
-    return GetPointer<const flatbuffers::Vector<float> *>(VT_DATA);
+  const flatbuffers::Vector<uint32_t> *data() const {
+    return GetPointer<const flatbuffers::Vector<uint32_t> *>(VT_DATA);
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -2224,7 +2224,7 @@ struct frameDataIndex FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 struct frameDataIndexBuilder {
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_data(flatbuffers::Offset<flatbuffers::Vector<float>> data) {
+  void add_data(flatbuffers::Offset<flatbuffers::Vector<uint32_t>> data) {
     fbb_.AddOffset(frameDataIndex::VT_DATA, data);
   }
   explicit frameDataIndexBuilder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -2241,7 +2241,7 @@ struct frameDataIndexBuilder {
 
 inline flatbuffers::Offset<frameDataIndex> CreateframeDataIndex(
     flatbuffers::FlatBufferBuilder &_fbb,
-    flatbuffers::Offset<flatbuffers::Vector<float>> data = 0) {
+    flatbuffers::Offset<flatbuffers::Vector<uint32_t>> data = 0) {
   frameDataIndexBuilder builder_(_fbb);
   builder_.add_data(data);
   return builder_.Finish();
@@ -2249,10 +2249,10 @@ inline flatbuffers::Offset<frameDataIndex> CreateframeDataIndex(
 
 inline flatbuffers::Offset<frameDataIndex> CreateframeDataIndexDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
-    const std::vector<float> *data = nullptr) {
+    const std::vector<uint32_t> *data = nullptr) {
   return ss::ssfb::CreateframeDataIndex(
       _fbb,
-      data ? _fbb.CreateVector<float>(*data) : 0);
+      data ? _fbb.CreateVector<uint32_t>(*data) : 0);
 }
 
 struct userDataInteger FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {


### PR DESCRIPTION
Player側で対応可能であることを確認しました。
このbranchはflatbuffers v1.9.0ベースなので、マージ後にPlayer側の更新を行います。