### PR TITLE
SDK,viewer2のメモリリーク対策

### DIFF
--- a/Build/Viewer2/Source/Controller/Main.cpp
+++ b/Build/Viewer2/Source/Controller/Main.cpp
@@ -28,7 +28,7 @@ public:
     {
         // This method is where you should put your application's initialisation code..
 
-        mainWindow = new MainWindow (getApplicationName());
+        mainWindow.reset(new MainWindow (getApplicationName()));
     }
 
     void shutdown() override
@@ -93,7 +93,7 @@ public:
     };
 
 private:
-    ScopedPointer<MainWindow> mainWindow;
+    std::unique_ptr<MainWindow> mainWindow;
 };
 
 //==============================================================================

--- a/Build/Viewer2/Source/Controller/MainComponent.cpp
+++ b/Build/Viewer2/Source/Controller/MainComponent.cpp
@@ -10,6 +10,7 @@
 #include "Model/Player.h"
 #include "View/DocumentView3D.h"
 #include "View/MainWindow.h"
+#include "babel/babel.h"
 
 MainContentComponent* MainContentComponent::myInst = nullptr;
 

--- a/Build/Viewer2/Source/Model/Loader.h
+++ b/Build/Viewer2/Source/Model/Loader.h
@@ -1,7 +1,5 @@
 ﻿#pragma once
-
 #include "../JuceLibraryCode/JuceHeader.h"
-#include "ssHelper.h"
 
 class AsyncAnimeLoader : public ThreadWithProgressWindow
 {

--- a/Build/Viewer2/Source/Model/Player.h
+++ b/Build/Viewer2/Source/Model/Player.h
@@ -9,11 +9,7 @@
 */
 
 #pragma once
-
 #include "../JuceLibraryCode/JuceHeader.h"
-#include "ssHelper.h"
-#include "ssplayer_animedecode.h"
-#include "ssplayer_render_gl.h"
 
 class SsProject;
 class SsAnimePack;
@@ -53,7 +49,6 @@ class Player : public juce::HighResolutionTimer
 		virtual void	draw(Player * p);
 		virtual void	loadProj(Player * p, const String & name);
 		virtual void	loadAnime(Player * p, int packIndex, int animeIndex);
-		virtual void	changeState(Player * p, State * newState);
 		virtual void	onEnter(Player * p) {};
 		virtual void	onLeave(Player * p) {};
 		JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(State)
@@ -117,24 +112,18 @@ public:
 	void	stop();
 	void	reset();
 	void	loadProj(const String & name);
-	void	preloadTexture();
-	void	unloadTexture();
 	void	loadAnime(int packIndex, int animeIndex);
-	void	setAnime(int packIndex, int animeIndex);
-	void	initGL();
 	State *	getState();
 	static void	drawAnime();
 
 	// アニメーションの状態
-	ScopedPointer<StatePlaying>		statePlaying;
-	ScopedPointer<StatePaused>		statePaused;
-	ScopedPointer<StateLoading>		stateLoading;
-	ScopedPointer<StateInitial>		stateInitial;
-	ScopedPointer<SsProject>		currentProj;
-	ScopedPointer<SsAnimeDecoder>	decoder;
-	ScopedPointer<SSTextureFactory>	texfactory;
-	ScopedPointer<SsRenderGL>		rendererGL;
-	SsCellMapList *					cellmap = nullptr;
+	std::unique_ptr<StatePlaying>		statePlaying;
+	std::unique_ptr<StatePaused>		statePaused;
+	std::unique_ptr<StateLoading>		stateLoading;
+	std::unique_ptr<StateInitial>		stateInitial;
+	std::unique_ptr<SsProject>			currentProj;
+	std::unique_ptr<SsAnimeDecoder>		decoder;
+	std::unique_ptr<SsCellMapList>		cellmap;
 
 	friend class AsyncAnimeLoader;
 	friend class AsyncProjectLoader;

--- a/Build/Viewer2/Source/View/DocumentView3D.cpp
+++ b/Build/Viewer2/Source/View/DocumentView3D.cpp
@@ -1,9 +1,11 @@
 ﻿#include <GL/glew.h>
+#include "OpenGL/SSTextureGL.h"
+#include "ssplayer_render_gl.h"
+#include "ssplayer_shader_gl.h"
 #include "Controller/MainComponent.h"
 #include "Model/Player.h"
 #include "View/DocumentView3D.h"
 #include "View/MainWindow.h"
-#include "ssplayer_shader_gl.h"
 
 DocumentView3D::DocumentView3D()
 {
@@ -18,11 +20,18 @@ DocumentView3D::~DocumentView3D()
 
 void DocumentView3D::initialise()
 {
-	Player::get()->initGL();
+#if JUCE_WINDOWS
+	GLenum err = glewInit();
+#endif
+
+	rendererGL.reset(new SsRenderGL());
+	SsCurrentRenderer::SetCurrentRender(rendererGL.get());
+	texfactory.reset(new SSTextureFactory(new SSTextureGL()));
 }
 
 void DocumentView3D::shutdown()
 {
+	SSTextureFactory::releaseAllTexture();
 	SSOpenGLShaderMan::Destory();
 }
 

--- a/Build/Viewer2/Source/View/DocumentView3D.h
+++ b/Build/Viewer2/Source/View/DocumentView3D.h
@@ -1,6 +1,9 @@
 ﻿#pragma once
 #include "../JuceLibraryCode/JuceHeader.h"
 
+class SSTextureFactory;
+class SsRenderGL;
+
 class DocumentView3D : public OpenGLAppComponent
 {
 public:
@@ -22,6 +25,8 @@ public:
 	void setBackGroundColour(const Colour & colour);
 
 private:
+	std::unique_ptr<SSTextureFactory>	texfactory;
+	std::unique_ptr<SsRenderGL>			rendererGL;
 	Colour	backGroundColour;
 	//==============================================================================
 	// private member variables

--- a/Build/Viewer2/Source/View/MainWindow.h
+++ b/Build/Viewer2/Source/View/MainWindow.h
@@ -1,6 +1,5 @@
 ﻿#pragma once
 #include "../JuceLibraryCode/JuceHeader.h"
-#include "ssHelper.h"
 
 class ViewerTreeViewItem;
 class ColourSelectorWindow;
@@ -44,24 +43,23 @@ public:
 	State *	getState();
     //==============================================================================
 private:
-	friend class WidgetCreator;
 	static ViewerMainWindow *	myInst;
 	// メニューバー
-	ScopedPointer<MenuBarComponent>	menuBar;
+	std::unique_ptr<MenuBarComponent>	menuBar;
 	// OpenGL描画領域
-	ScopedPointer<DocumentView3D>	opengl;
+	std::unique_ptr<DocumentView3D>	opengl;
 	// ウィジェット
-	ScopedPointer<TextButton>		button_start;
-	ScopedPointer<TextButton>		button_stop;
-	ScopedPointer<TextButton>		button_reset;
-	ScopedPointer<TextButton>		button_loop;
-	ScopedPointer<Slider>			slider_frame;
-	ScopedPointer<TreeView>			animeTreeView;
-	ScopedPointer<PropertyPanel>	propertyPanel;
+	std::unique_ptr<TextButton>		button_start;
+	std::unique_ptr<TextButton>		button_stop;
+	std::unique_ptr<TextButton>		button_reset;
+	std::unique_ptr<TextButton>		button_loop;
+	std::unique_ptr<Slider>			slider_frame;
+	std::unique_ptr<TreeView>		animeTreeView;
+	std::unique_ptr<PropertyPanel>	propertyPanel;
 	Component::SafePointer<ColourSelectorWindow>	colourSelectorWindow;
 	// レイアウト
-	ScopedPointer<Component>		controlPanel;
-	ScopedPointer<ConcertinaPanel>	sidePanel;
+	std::unique_ptr<Component>		controlPanel;
+	std::unique_ptr<ConcertinaPanel>sidePanel;
 	// 最近開いたファイルリスト
 	RecentlyOpenedFilesList			recentlyOpenedFilesList;
 	// ビューの状態
@@ -102,7 +100,7 @@ public:
 	ColourSelectorWindow(const String & name, Colour backgroundColour, int buttonsNeeded);
 	void closeButtonPressed() override;
 private:
-	ScopedPointer<ColourSelector> selector;
+	std::unique_ptr<ColourSelector> selector;
 	JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ColourSelectorWindow)
 };
 

--- a/Common/Animator/ssplayer_PartState.cpp
+++ b/Common/Animator/ssplayer_PartState.cpp
@@ -1,5 +1,7 @@
 ﻿#include "../Loader/ssloader.h"
 #include "ssplayer_animedecode.h"
+#include "ssplayer_mesh.h"
+#include "ssplayer_effect2.h"
 #include "ssplayer_PartState.h"
 
 SsPartState::SsPartState() : refAnime(0), index(-1), parent(nullptr), noCells(false), alphaBlendType(SsBlendType::invalid),	refEffect(0) , 	meshPart(0)

--- a/Common/Animator/ssplayer_animedecode.cpp
+++ b/Common/Animator/ssplayer_animedecode.cpp
@@ -42,7 +42,19 @@ SsAnimeDecoder::SsAnimeDecoder() :
 	maskParentSetting(true),
 	meshAnimator(0)
 	{
+		meshAnimator = new SsMeshAnimator();
 	}
+
+SsAnimeDecoder::~SsAnimeDecoder()
+{
+	if ( partState )
+		delete [] partState;
+	delete meshAnimator;
+	for (auto itr = subCellMapManagerList.begin(); itr != subCellMapManagerList.end(); itr++)
+	{
+		delete *itr;
+	}
+}
 
 
 void	SsAnimeDecoder::reset()
@@ -198,8 +210,9 @@ void	SsAnimeDecoder::setAnimation( SsModel*	model , SsAnimation* anime , SsCellM
 				SsAnimation* refanime = refpack->findAnimation( p->refAnime );
 
 				SsCellMapList* __cellmap = new SsCellMapList();
+				subCellMapManagerList.push_back(__cellmap);
 				__cellmap->set( sspj , refpack );
-				SsAnimeDecoder* animedecoder = new SsAnimeDecoder();
+				auto * animedecoder = new SsAnimeDecoder();
 
 				//インスタンスパーツの設定setAnimationでソースアニメになるパーツに適用するので先に設定を行う
 				animedecoder->setMaskFuncFlag(false);					//マスク機能を無効にする
@@ -270,7 +283,6 @@ void	SsAnimeDecoder::setAnimation( SsModel*	model , SsAnimation* anime , SsCellM
 	curAnimeFPS = anime->settings.fps;
 
 	//メッシュアニメーションを初期化
-	meshAnimator = new SsMeshAnimator();
 	meshAnimator->setAnimeDecoder(this);
 	meshAnimator->makeMeshBoneList();
 

--- a/Common/Animator/ssplayer_animedecode.h
+++ b/Common/Animator/ssplayer_animedecode.h
@@ -84,6 +84,8 @@ private:
 	SsMeshAnimator*	meshAnimator;
 	SsModel*		myModel;
 
+	std::vector<SsCellMapList*>		subCellMapManagerList;	//内部で生成したオブジェクト解体用
+
 private:
 	void	updateState( int nowTime , SsPart* part , SsPartAnime* part_anime , SsPartState* state );
 	void	updateInstance( int nowTime , SsPart* part , SsPartAnime* part_anime , SsPartState* state );
@@ -101,14 +103,7 @@ private:
 
 public:
 	SsAnimeDecoder();
-	virtual ~SsAnimeDecoder()
-	{
-		if ( curCellMapManager )
-			delete curCellMapManager;
-
-		if ( partState )
-			delete [] partState;
-	}
+	virtual ~SsAnimeDecoder();
 
 	virtual void	update( float frameDelta = 1.0f );
 	virtual void	draw();

--- a/Common/Drawer/ssplayer_render_gl.cpp
+++ b/Common/Drawer/ssplayer_render_gl.cpp
@@ -178,13 +178,20 @@ static void __fastcall setupSimpleTextureCombiner_for_PartsColor_(SsBlendType::_
 	}
 }
 
+SsRenderGL::~SsRenderGL()
+{
+	delete vs;
+	delete fs1;
+	delete fs2;
+}
+
 void	SsRenderGL::initialize()
 {
 //	if ( m_isInit ) return ;
 	SSOpenGLShaderMan::Create();
-	SSOpenGLVertexShader*	vs = new SSOpenGLVertexShader( "basic_vs" , glshader_sprite_vs );
-	SSOpenGLFragmentShader*	fs1 = new SSOpenGLFragmentShader( "normal_fs" , glshader_sprite_fs );
-	SSOpenGLFragmentShader*	fs2 = new SSOpenGLFragmentShader( "pot_fs" ,glshader_sprite_fs_pot );
+	vs = new SSOpenGLVertexShader( "basic_vs" , glshader_sprite_vs );
+	fs1 = new SSOpenGLFragmentShader( "normal_fs" , glshader_sprite_fs );
+	fs2 = new SSOpenGLFragmentShader( "pot_fs" ,glshader_sprite_fs_pot );
 
 	SSOpenGLProgramObject* pgo1 = new SSOpenGLProgramObject();
 	SSOpenGLProgramObject* pgo2 = new SSOpenGLProgramObject();

--- a/Common/Drawer/ssplayer_render_gl.h
+++ b/Common/Drawer/ssplayer_render_gl.h
@@ -5,16 +5,20 @@
 
 struct SsPartState;
 class SsMeshPart;
-
+class SSOpenGLVertexShader;
+class SSOpenGLFragmentShader;
+class SSOpenGLFragmentShader;
 
 class SsRenderGL : public ISsRenderer
 {
 private:
 	//static bool	m_isInit;
-
+	SSOpenGLVertexShader*	vs;
+	SSOpenGLFragmentShader*	fs1;
+	SSOpenGLFragmentShader*	fs2;
 public:
-	SsRenderGL(){}
-	virtual ~SsRenderGL(){}
+	SsRenderGL() : vs(0), fs1(0), fs2(0) {};
+	virtual ~SsRenderGL();
 
 	virtual void	initialize();
 	virtual void	renderSetup();

--- a/Common/Loader/SsEffectBehavior.cpp
+++ b/Common/Loader/SsEffectBehavior.cpp
@@ -56,3 +56,11 @@ void	SsEffectBehavior::EffectElementLoader(ISsXmlArchiver* ar)
 	}
 
 }
+
+SsEffectBehavior::~SsEffectBehavior()
+{
+	for (auto itr = plist.begin(); itr != plist.end(); itr++)
+	{
+		delete *itr;
+	}
+}

--- a/Common/Loader/SsEffectBehavior.h
+++ b/Common/Loader/SsEffectBehavior.h
@@ -21,7 +21,7 @@ public:
 
 public:
 	SsEffectBehavior() : refCell(0),BlendType(SsRenderBlendType::invalid) {}
-	virtual ~SsEffectBehavior(){}
+	virtual ~SsEffectBehavior();
 
 	SSSERIALIZE_BLOCK
 	{

--- a/Common/Loader/ssloader_ssae.h
+++ b/Common/Loader/ssloader_ssae.h
@@ -264,6 +264,8 @@ public:
 	{
 		for ( std::vector<SsPart*>::iterator itr = partList.begin() ; 
 			itr != partList.end() ; itr ++ ) delete (*itr);
+		for ( std::vector<SsMeshBind*>::iterator itr = meshList.begin() ; 
+			itr != meshList.end() ; itr ++ ) delete (*itr);
 	}
 
 	///シリアライズのための宣言です。

--- a/Common/Loader/ssvalue.h
+++ b/Common/Loader/ssvalue.h
@@ -114,6 +114,7 @@ public:
 		if (this != &x) {
 		  this->release();
 		  name.~SsString();
+		  org_txt.~SsString();
 		  new (this) SsValue(x);
 		}
 		return *this;


### PR DESCRIPTION
### 主な変更点
1. SDKのメモリリーク対策
2. Viewer2 : ScopedPointer -> std::unique_ptr