### PR TITLE
ビルドエラー修正

### DIFF
--- a/Build/CMakeLists.txt
+++ b/Build/CMakeLists.txt
@@ -44,8 +44,5 @@ ENDIF()
 
 enable_testing()
 
-# viewer_sample_gl and viewer_sample_dx9
-add_subdirectory(Viewer)
-
 # Ss6Converter
 add_subdirectory(Converter)


### PR DESCRIPTION
https://github.com/SpriteStudio/SpriteStudio6-SDK/pull/71 の作業にて Viewer サブモジュールの消し忘れがありました。