### PR TITLE
Juce2CMake instead of Jucer2Reprojucer

### DIFF
--- a/Scripts/build_viewer2_macos.sh
+++ b/Scripts/build_viewer2_macos.sh
@@ -7,7 +7,7 @@ BASEDIR=`cd ${BASEDIR} && pwd -P`
 BUILDDIR=${BASEDIR}/Build
 BUILDDIR=`cd ${BUILDDIR} && pwd -P`
 
-Jucer2Reprojucer=${BUILDDIR}/Viewer2/FRUT/prefix/FRUT/bin/Jucer2Reprojucer
+Jucer2CMake=${BUILDDIR}/Viewer2/FRUT/prefix/FRUT/bin/Jucer2CMake
 
 BUILDTYPE=Debug
 if [ $# -ge 1 ]; then
@@ -16,7 +16,7 @@ fi
 
 # generate CMakeLists.txt
 pushd ${BUILDDIR}/Viewer2
-${Jucer2Reprojucer} ./Viewer2.jucer ./FRUT/prefix/FRUT/cmake/Reprojucer.cmake  --juce-modules ./JUCE/modules
+${Jucer2CMake} reprojucer ./Viewer2.jucer ./FRUT/prefix/FRUT/cmake/Reprojucer.cmake  --juce-modules $(pwd)/JUCE/modules
 
 /bin/rm -rf cmakeBuild
 mkdir cmakeBuild

--- a/Scripts/build_viewer2_win.bat
+++ b/Scripts/build_viewer2_win.bat
@@ -3,8 +3,7 @@ setlocal
 set CURDIR=%~dp0
 set BASEDIR=%CURDIR%..
 set BUILDDIR=%BASEDIR%\Build
-set DEPENDSDIR=%BUILDDIR%\Depends
-set Jucer2Reprojucer=%BUILDDIR%\Viewer2\FRUT\prefix\FRUT\bin\Jucer2Reprojucer.exe
+set Jucer2CMake=%BUILDDIR%\Viewer2\FRUT\prefix\FRUT\bin\Jucer2CMake.exe
 @echo on
 
 set BUILD_TYPE=Debug
@@ -13,7 +12,7 @@ if not "%1" == "" (
 )
 
 pushd %BUILDDIR%\Viewer2
-%Jucer2Reprojucer% Viewer2.jucer FRUT\prefix\FRUT\cmake\Reprojucer.cmake  --juce-modules JUCE\modules
+%Jucer2CMake%  reprojucer Viewer2.jucer FRUT\prefix\FRUT\cmake\Reprojucer.cmake  --juce-modules %CURDIR%\JUCE\modules
 
 rmdir /S /Q cmakeBuild
 mkdir cmakeBuild

--- a/Scripts/build_viewer2_win.bat
+++ b/Scripts/build_viewer2_win.bat
@@ -12,7 +12,7 @@ if not "%1" == "" (
 )
 
 pushd %BUILDDIR%\Viewer2
-%Jucer2CMake%  reprojucer Viewer2.jucer FRUT\prefix\FRUT\cmake\Reprojucer.cmake  --juce-modules %CURDIR%\JUCE\modules
+%Jucer2CMake%  reprojucer Viewer2.jucer FRUT\prefix\FRUT\cmake\Reprojucer.cmake  --juce-modules %BUILDDIR%\Viewer2\JUCE\modules
 
 rmdir /S /Q cmakeBuild
 mkdir cmakeBuild

--- a/Scripts/prepare_build_viewer2_macos.sh
+++ b/Scripts/prepare_build_viewer2_macos.sh
@@ -13,7 +13,7 @@ pushd ${BUILDDIR}/Viewer2
 git clone --branch=6.0.1 --depth=1 --single-branch https://github.com/WeAreROLI/JUCE.git
 git clone https://github.com/McMartin/FRUT.git
 
-# create Jucer2Reprojucer command
+# create Jucer2CMake command
 pushd FRUT
 mkdir build 
 pushd build

--- a/Scripts/prepare_build_viewer2_win.bat
+++ b/Scripts/prepare_build_viewer2_win.bat
@@ -3,7 +3,6 @@ setlocal
 set CURDIR=%~dp0
 set BASEDIR=%CURDIR%..
 set BUILDDIR=%BASEDIR%\Build
-set DEPENDSDIR=%BUILDDIR%\Depends
 @echo on
 
 pushd %BUILDDIR%\Viewer2
@@ -12,7 +11,7 @@ rmdir /S /Q FRUT
 git clone --branch=6.0.1 --depth=1 --single-branch https://github.com/WeAreROLI/JUCE.git || exit /b 1
 git clone https://github.com/McMartin/FRUT.git || exit /b 1
 
-rem create Jucer2Reprojucer command
+rem create Jucer2CMake command
 pushd FRUT
 mkdir build 
 pushd build


### PR DESCRIPTION
JUCE プロジェクトから CMakeList.txt を生成する https://github.com/McMartin/FRUT の `Jucer2Reprojucer` コマンドが deprecated になり 2021 年に削除されるため、 `Juce2CMake` コマンドへの移行作業となります。