### PR TITLE
・SpriteStudio6-SDK専用の名前空間「spritestudio6」を作成・その下に実装されるように変更

### DIFF
--- a/Build/Converter/LumpExporter.cpp
+++ b/Build/Converter/LumpExporter.cpp
@@ -36,7 +36,7 @@ static std::string encode(const std::string& str, StringEncoding encoding)
 {
 	switch (encoding) {
 		case UTF8: return str;
-		case SJIS: return SsCharConverter::utf8_to_sjis(str); // TODO:
+		case SJIS: return spritestudio6::SsCharConverter::utf8_to_sjis(str); // TODO:
 		default:
 			break;
 	}
@@ -1212,7 +1212,7 @@ private:
 					for(auto frameDataItem : frameDataVec) {
 						switch (frameDataItem->type) {
 						case Lump::DataType::S32:
-							ssfbUV.push_back(GETS32(frameDataItem));
+							ssfbUV.push_back((float)(GETS32(frameDataItem)));
 							break;
 						case Lump::DataType::FLOAT:
 							ssfbUV.push_back(GETFLOAT(frameDataItem));
@@ -1235,7 +1235,7 @@ private:
 				    std::vector<float> ssfbIndices;
 					auto meshsDataVec = meshsDataIndicesItem->getChildren();
 					for(auto meshDataItem : meshsDataVec) {
-						ssfbIndices.push_back(GETS32(meshDataItem));
+						ssfbIndices.push_back((float)(GETS32(meshDataItem)));
 					}
 
 					auto serializeSsfbIndices = createSharedFloatVec(ssfbIndices);
@@ -1699,7 +1699,7 @@ private:
 			auto ssfbEffectFile = ss::ssfb::CreateEffectFile(m_ssfbBuilder, ssfbEffectFileName,
                                                              fps, isLockRandSeed, LockRandSeed,
                                                              layoutScaleX, layoutScaleY,
-                                                             ssfbEffectNode.size(), serializeSsfbEffectNode);
+                                                             (int16_t)(ssfbEffectNode.size()), serializeSsfbEffectNode);
 			m_ssfbEffectFileList.push_back(ssfbEffectFile);
 		}
 	}

--- a/Build/Converter/main.cpp
+++ b/Build/Converter/main.cpp
@@ -1699,31 +1699,54 @@ void convertProject(const std::string& outPath, LumpExporter::StringEncoding enc
 	}
 	else
 	{
-
 		std::fstream out;
+		static const std::string messageErrorFileOpen = "出力ファイルのオープンに失敗しました: ";
 
 		if (outputFormat == OUTPUT_FORMAT_FLAG_JSON)
 		{
-			out.open((outPath + ".json").c_str(), std::ios_base::out);
-			LumpExporter::saveJson(out, encoding, lump, creatorComment);
+//			out.open((outPath + ".json").c_str(), std::ios_base::out);
+			std::string outPathJson = outPath + ".json";
+			out.open(outPathJson.c_str(), std::ios_base::out);
+			if(out)
+			{
+				LumpExporter::saveJson(out, encoding, lump, creatorComment);
+			}
+			else
+			{
+				std::cerr << messageErrorFileOpen << outPathJson << std::endl;
+			}
 		}
 		else if (outputFormat == OUTPUT_FORMAT_FLAG_CSOURCE)
 		{
-
 			// out.open((outPath + ".c").c_str(), std::ios_base::out);
 			// LumpExporter::saveCSource(out, encoding, lump, "topLabel", creatorComment);
 			std::cerr << "*** OBSOLETE C LANGUAGE SOURCE FORMAT. ***"  << std::endl;
-
 		}
 		else if (outputFormat == OUTPUT_FORMAT_FLAG_SSFB)
 		{
-			out.open((outPath + ".ssfb").c_str(), std::ios_base::binary | std::ios_base::out);
-            LumpExporter::saveSsfb(out, encoding, lump, creatorComment, s_frameIndexVec);
+//			out.open((outPath + ".ssfb").c_str(), std::ios_base::binary | std::ios_base::out);
+			std::string outPathSsfb = outPath + ".ssfb";
+			out.open(outPathSsfb.c_str(), std::ios_base::binary | std::ios_base::out);
+			if(out)
+			{
+				LumpExporter::saveSsfb(out, encoding, lump, creatorComment, s_frameIndexVec);
+			}
+			else
+			{
+				std::cerr << messageErrorFileOpen << outPathSsfb << std::endl;
+			}
 		}
 		else
 		{
 			out.open(outPath.c_str(), std::ios_base::binary | std::ios_base::out);
-			LumpExporter::saveBinary(out, encoding, lump, creatorComment);
+			if(out)
+			{
+				LumpExporter::saveBinary(out, encoding, lump, creatorComment);
+			}
+			else
+			{
+				std::cerr << messageErrorFileOpen << outPath << std::endl;
+			}
 		}
 
 	/////////////

--- a/Build/Converter/main.cpp
+++ b/Build/Converter/main.cpp
@@ -125,21 +125,21 @@ union converter32 {
 converter32 c32;
 
 
-typedef std::map<const SsCell*, int> CellList;
+typedef std::map<const spritestudio6::SsCell*, int> CellList;
 
-CellList* makeCellList(SsProject* proj)
+CellList* makeCellList(spritestudio6::SsProject* proj)
 {
 	// セルデータの出力と、全てセルデータを集約したリストを作る
-	CellList* cellList = new std::map<const SsCell*, int>();
+	CellList* cellList = new std::map<const spritestudio6::SsCell*, int>();
 	int cellListIndex = 0;
 
 	for (size_t mapIndex = 0; mapIndex < proj->cellmapList.size(); mapIndex++)
 	{
-		const SsCellMap* cellMap = proj->cellmapList[mapIndex];
+		const spritestudio6::SsCellMap* cellMap = proj->cellmapList[mapIndex];
 
 		for (size_t cellIndex = 0; cellIndex < cellMap->cells.size(); cellIndex++)
 		{
-			const SsCell* cell = cellMap->cells[cellIndex];
+			const spritestudio6::SsCell* cell = cellMap->cells[cellIndex];
 			cellList->insert(CellList::value_type(cell, cellListIndex++));
 		}
 	}
@@ -148,20 +148,20 @@ CellList* makeCellList(SsProject* proj)
 }
 
 
-static const SsKeyframe* findDefaultKeyframe(SsAnimeDecoder& decoder, int partIndex, SsAttributeKind::_enum tag)
+static const spritestudio6::SsKeyframe* findDefaultKeyframe(spritestudio6::SsAnimeDecoder& decoder, int partIndex, spritestudio6::SsAttributeKind::_enum tag)
 {
-	foreach(std::vector<SsPartAndAnime>, decoder.getPartAnime(), it)
+	SPRITESTUDIO6DSK_foreach(std::vector<spritestudio6::SsPartAndAnime>, decoder.getPartAnime(), it)
 	{
-		SsPartAnime* partAnime = it->second;
-		SsPart* part = it->first;
+		spritestudio6::SsPartAnime* partAnime = it->second;
+		spritestudio6::SsPart* part = it->first;
 		if (part->arrayIndex != partIndex) continue;
-		
-		foreach(SsAttributeList, partAnime->attributes, attrIt)
+
+		SPRITESTUDIO6DSK_foreach(spritestudio6::SsAttributeList, partAnime->attributes, attrIt)
 		{
-			SsAttribute* attr = *attrIt;
+			spritestudio6::SsAttribute* attr = *attrIt;
 			if (attr->tag != tag) continue;
 			
-			const SsKeyframe* key = attr->firstKey();
+			const spritestudio6::SsKeyframe* key = attr->firstKey();
 			return key;
 		}
 		
@@ -170,20 +170,20 @@ static const SsKeyframe* findDefaultKeyframe(SsAnimeDecoder& decoder, int partIn
 }
 
 
-static SsAttribute* findAttribute(SsPartAnime* partAnime, SsAttributeKind::_enum tag)
+static spritestudio6::SsAttribute* findAttribute(spritestudio6::SsPartAnime* partAnime, spritestudio6::SsAttributeKind::_enum tag)
 {
-	foreach(SsAttributeList, partAnime->attributes, attrIt)
+	SPRITESTUDIO6DSK_foreach(spritestudio6::SsAttributeList, partAnime->attributes, attrIt)
 	{
-		SsAttribute* attr = *attrIt;
+		spritestudio6::SsAttribute* attr = *attrIt;
 		if (attr->tag == tag) return attr;
 	}
 	return NULL;
 }
 
 
-static const SsKeyframe* findFirstKey(SsPartAnime* partAnime, SsAttributeKind::_enum tag)
+static const spritestudio6::SsKeyframe* findFirstKey(spritestudio6::SsPartAnime* partAnime, spritestudio6::SsAttributeKind::_enum tag)
 {
-	SsAttribute* attr = findAttribute(partAnime, tag);
+	spritestudio6::SsAttribute* attr = findAttribute(partAnime, tag);
 	if (attr)
 	{
 		return attr->firstKey();
@@ -192,11 +192,11 @@ static const SsKeyframe* findFirstKey(SsPartAnime* partAnime, SsAttributeKind::_
 }
 
 
-static const SsPartState* findState(std::list<SsPartState*>& partList, int partIndex)
+static const spritestudio6::SsPartState* findState(std::list<spritestudio6::SsPartState*>& partList, int partIndex)
 {
-	foreach (std::list<SsPartState*>, partList, it)
+	SPRITESTUDIO6DSK_foreach(std::list<spritestudio6::SsPartState*>, partList, it)
 	{
-		const SsPartState* state = *it;
+		const spritestudio6::SsPartState* state = *it;
 		if (state->index == partIndex) return state;
 	}
 	return NULL;
@@ -254,11 +254,11 @@ struct PartInitialData
 
 
 //全全角が使われてるかのチェック
-bool isZenkaku( const SsString* str )
+bool isZenkaku( const spritestudio6::SsString* str )
 {
 	bool rc = false;
 	int i = 0;
-	int size = str->length();
+	int size = (int)str->length();
 	const char *c = str->c_str();
 
 	while ( true )
@@ -282,11 +282,11 @@ bool isZenkaku( const SsString* str )
 
 static std::vector<int16_t> s_frameIndexVec;
 
-static void parseParts_ssqe(Lump* topLump, SsProject* proj, const std::string& imageBaseDir)
+static void parseParts_ssqe(Lump* topLump, spritestudio6::SsProject* proj, const std::string& imageBaseDir)
 {
 }
 
-static Lump* parseParts(SsProject* proj, const std::string& imageBaseDir)
+static Lump* parseParts(spritestudio6::SsProject* proj, const std::string& imageBaseDir)
 {
 //	static SsPartStateLess _ssPartStateLess;
 	std::cerr << SPRITESTUDIOSDK_VERSION << "\n";	//バージョン表記は ssloader.h　にあります。
@@ -297,7 +297,7 @@ static Lump* parseParts(SsProject* proj, const std::string& imageBaseDir)
 
 	Lump* topLump = Lump::set("ss::ProjectData", true, "ProjectData");
 
-	if (checkFileVersion(proj->version, SPRITESTUDIO6_SSPJVERSION) == false)
+	if (spritestudio6::checkFileVersion(proj->version, SPRITESTUDIO6_SSPJVERSION) == false)
 	{
 		std::cerr << "エラー：SpriteStudio Ver.5.xのプロジェクトは使用できません。\n";
 		std::cerr << "SpriteStudio Ver.6.xで保存する必要があります。\n";
@@ -346,7 +346,7 @@ static Lump* parseParts(SsProject* proj, const std::string& imageBaseDir)
 	// セルの情報
 	for (size_t mapIndex = 0; mapIndex < proj->cellmapList.size(); mapIndex++)
 	{
-		const SsCellMap* cellMap = proj->cellmapList[mapIndex];
+		const spritestudio6::SsCellMap* cellMap = proj->cellmapList[mapIndex];
 
 		Lump* cellMapData = Lump::set("ss::CellMap", true, "CellMap");
 		cellMapData->add(Lump::stringData(cellMap->name, "name"));
@@ -389,7 +389,7 @@ static Lump* parseParts(SsProject* proj, const std::string& imageBaseDir)
 		}
 		for (size_t cellIndex = 0; cellIndex < cellMap->cells.size(); cellIndex++)
 		{
-			const SsCell* cell = cellMap->cells[cellIndex];
+			const spritestudio6::SsCell* cell = cellMap->cells[cellIndex];
 
 			Lump* cellData = Lump::set("ss::Cell", false, "Cell");
 			cellsData->add(cellData);
@@ -434,8 +434,8 @@ static Lump* parseParts(SsProject* proj, const std::string& imageBaseDir)
 	// パーツ、アニメ情報
 	for (int packIndex = 0; packIndex < (int)proj->animeList.size(); packIndex++)
 	{
-		const SsAnimePack* animePack = proj->animeList[packIndex];
-		const SsModel& model = animePack->Model;
+		const spritestudio6::SsAnimePack* animePack = proj->animeList[packIndex];
+		const spritestudio6::SsModel& model = animePack->Model;
 		
 		// AnimePackData
 		Lump* animePackData = Lump::set("ss::AnimePackData", false, "AnimePackData");
@@ -461,7 +461,7 @@ static Lump* parseParts(SsProject* proj, const std::string& imageBaseDir)
 		// パーツ情報（モデル）の出力
 		for (int partIndex = 0; partIndex < (int)model.partList.size(); partIndex++)
 		{
-			const SsPart* part = model.partList[partIndex];
+			const spritestudio6::SsPart* part = model.partList[partIndex];
 
 			// PartData
 			Lump* partData = Lump::set("ss::PartData", false, "PartData" );
@@ -482,26 +482,26 @@ static Lump* parseParts(SsProject* proj, const std::string& imageBaseDir)
 			//5.5対応5.3.5に無いパーツ種別がある場合ワーニングを表示する
 			switch (part->type)
 			{
-			case SsPartType::null:			// null。領域を持たずSRT情報のみ。ただし円形の当たり判定は設定可能。
-			case SsPartType::normal:		// 通常パーツ。領域を持つ。画像は無くてもいい。
-			case SsPartType::mask:			// 6.0マスクパーツ
-			case SsPartType::constraint:	// 6.0コンストレイントパーツ
-			case SsPartType::bonepoint:		// 6.0ボーンエフェクトパーツ
-			case SsPartType::joint:			// 6.0ジョイントパーツ
-			case SsPartType::armature:		// 6.0ボーンパーツ
-			case SsPartType::mesh:			// 6.0メッシュパーツ
+			case spritestudio6::SsPartType::null:			// null。領域を持たずSRT情報のみ。ただし円形の当たり判定は設定可能。
+			case spritestudio6::SsPartType::normal:		// 通常パーツ。領域を持つ。画像は無くてもいい。
+			case spritestudio6::SsPartType::mask:			// 6.0マスクパーツ
+			case spritestudio6::SsPartType::constraint:	// 6.0コンストレイントパーツ
+			case spritestudio6::SsPartType::bonepoint:		// 6.0ボーンエフェクトパーツ
+			case spritestudio6::SsPartType::joint:			// 6.0ジョイントパーツ
+			case spritestudio6::SsPartType::armature:		// 6.0ボーンパーツ
+			case spritestudio6::SsPartType::mesh:			// 6.0メッシュパーツ
 				partData->add(Lump::s16Data(part->type, "type"));
 				break;
-			case SsPartType::instance:		// インスタンス。他アニメ、パーツへの参照。シーン編集モードの代替になるもの
+			case spritestudio6::SsPartType::instance:		// インスタンス。他アニメ、パーツへの参照。シーン編集モードの代替になるもの
 				//参照アニメのポインタが無い場合はNULLパーツになる。
 				{
-					SsString packname = part->refAnimePack;
-					SsString animename = part->refAnime;
-					SsAnimePack* refpack = proj->findAnimationPack(packname);
-					SsAnimation* refanime = refpack->findAnimation(animename);
+					spritestudio6::SsString packname = part->refAnimePack;
+					spritestudio6::SsString animename = part->refAnime;
+					spritestudio6::SsAnimePack* refpack = proj->findAnimationPack(packname);
+					spritestudio6::SsAnimation* refanime = refpack->findAnimation(animename);
 					if (refanime == NULL)
 					{
-						partData->add(Lump::s16Data(SsPartType::null, "type"));
+						partData->add(Lump::s16Data(spritestudio6::SsPartType::null, "type"));
 						std::cerr << "警告：参照のないインスタンスパーツが存在します: " << animePack->name << ".ssae " << part->name << "\n";
 					}
 					else
@@ -510,11 +510,11 @@ static Lump* parseParts(SsProject* proj, const std::string& imageBaseDir)
 					}
 				}
 				break;
-			case SsPartType::effect:		// 5.5エフェクトパーツ
+			case spritestudio6::SsPartType::effect:		// 5.5エフェクトパーツ
 				//参照エフェクト名が空の場合はNULLパーツになる。
 				if (part->refEffectName == "")
 				{
-					partData->add(Lump::s16Data(SsPartType::null, "type"));
+					partData->add(Lump::s16Data(spritestudio6::SsPartType::null, "type"));
 					//未実装　ワーニングを表示しNULLパーツにする
 					std::cerr << "警告：参照のないエフェクトパーツが存在します: " << animePack->name << ".ssae " << part->name << "\n";
 				}
@@ -526,7 +526,7 @@ static Lump* parseParts(SsProject* proj, const std::string& imageBaseDir)
 			default:
 				//未対応パーツ　ワーニングを表示しNULLパーツにする
 				std::cerr << "警告：未対応のパーツ種別が使われています: " << animePack->name << ".ssae " << part->name << "\n";
-				partData->add(Lump::s16Data(SsPartType::null, "type"));
+				partData->add(Lump::s16Data(spritestudio6::SsPartType::null, "type"));
 				break;
 			}
 			partData->add(Lump::s16Data(part->boundsType, "boundsType"));
@@ -536,29 +536,29 @@ static Lump* parseParts(SsProject* proj, const std::string& imageBaseDir)
 			//インスタンスアニメ名
 			if ( part->refAnime == "" )
 			{
-				const SsString str = "";
+				const spritestudio6::SsString str = "";
 //				partData->add(Lump::s16Data((int)str.length()));				//文字列のサイズ
 				partData->add(Lump::stringData(str, "refname"));							//文字列
 			}
 			else
 			{
-				const SsString str = part->refAnimePack + "/" + part->refAnime;
+				const spritestudio6::SsString str = part->refAnimePack + "/" + part->refAnime;
 //				partData->add(Lump::s16Data((int)str.length()));				//文字列のサイズ
 				partData->add(Lump::stringData(str, "refname"));							//文字列
 			}
 			//エフェクト名
 			if (part->refEffectName == "")
 			{
-				const SsString str = "";
+				const spritestudio6::SsString str = "";
 				partData->add(Lump::stringData(str, "effectfilename"));							//文字列
 			}
 			else
 			{
-				const SsString str = part->refEffectName;
+				const spritestudio6::SsString str = part->refEffectName;
 				partData->add(Lump::stringData(str, "effectfilename"));							//文字列
 			}
 			//カラーラベル
-			const SsString str = part->colorLabel;
+			const spritestudio6::SsString str = part->colorLabel;
 			partData->add(Lump::stringData(str, "colorLabel"));								//文字列
 
 			//マスク対象
@@ -567,19 +567,19 @@ static Lump* parseParts(SsProject* proj, const std::string& imageBaseDir)
 		}
 
 		// アニメ情報の出力
-		SsCellMapList* cellMapList = new SsCellMapList();	// SsAnimeDecoderのデストラクタで破棄される
-		SsAnimeDecoder decoder;
+		spritestudio6::SsCellMapList* cellMapList = new spritestudio6::SsCellMapList();	// SsAnimeDecoderのデストラクタで破棄される
+		spritestudio6::SsAnimeDecoder decoder;
 //		const SsKeyframe* key;
 
 		for (int animeIndex = 0; animeIndex < (int)animePack->animeList.size(); animeIndex++)
 		{
-			SsAnimePack* animePack = proj->getAnimePackList()[packIndex];
-			SsModel* model = &animePack->Model;
-			SsAnimation* anime = animePack->animeList[animeIndex];
+			spritestudio6::SsAnimePack* animePack = proj->getAnimePackList()[packIndex];
+			spritestudio6::SsModel* model = &animePack->Model;
+			spritestudio6::SsAnimation* anime = animePack->animeList[animeIndex];
 			
 			cellMapList->set(proj, animePack);
 			decoder.setAnimation(model, anime, cellMapList, proj);
-			std::list<SsPartState*>& partList = decoder.getPartSortList();
+			std::list<spritestudio6::SsPartState*>& partList = decoder.getPartSortList();
 			
 			// AnimationData
 			Lump* animeData = Lump::set("ss::AnimationData", false, "AnimationData");
@@ -595,12 +595,12 @@ static Lump* parseParts(SsProject* proj, const std::string& imageBaseDir)
 
 			Lump* initialDataArray = Lump::set("ss::AnimationInitialData[]", true, "AnimationInitialData");
 			int sortedOrder = 0;
-			foreach(std::vector<SsPartAndAnime>, decoder.getPartAnime(), it)
+			SPRITESTUDIO6DSK_foreach(std::vector<spritestudio6::SsPartAndAnime>, decoder.getPartAnime(), it)
 			{
-				SsPart* part = it->first;
-//				SsPartAnime* partAnime = it->second;
+				spritestudio6::SsPart* part = it->first;
+//				spritestudio6::SsPartAnime* partAnime = it->second;
 				
-				const SsPartState* state = findState(partList, part->arrayIndex);
+				const spritestudio6::SsPartState* state = findState(partList, part->arrayIndex);
 				
 				PartInitialData init;
 				init.sortedOrder = sortedOrder++;
@@ -644,7 +644,7 @@ static Lump* parseParts(SsProject* proj, const std::string& imageBaseDir)
 				//本来であればキーがないときはセルのサイズが初期値になる
 				init.size_X = state->size.x;
 				init.size_Y = state->size.y;
-				SsCell * cell = state->cellValue.cell;
+				spritestudio6::SsCell * cell = state->cellValue.cell;
 				if ( cell )
 				{
 					//セルデータがある場合はセルのサイズを初期値にする
@@ -736,17 +736,17 @@ static Lump* parseParts(SsProject* proj, const std::string& imageBaseDir)
 				decoder.setPlayFrame(0);
 				decoder.update();
 
-				foreach(std::vector<SsPartAndAnime>, decoder.getPartAnime(), it)
+				SPRITESTUDIO6DSK_foreach(std::vector<spritestudio6::SsPartAndAnime>, decoder.getPartAnime(), it)
 				{
-					SsPart* part = it->first;
-					const SsPartState* state = findState(partList, part->arrayIndex);
+					spritestudio6::SsPart* part = it->first;
+					const spritestudio6::SsPartState* state = findState(partList, part->arrayIndex);
 
 					//サイズ分のUV出力
 					Lump* meshData = Lump::set("ss::ss_u16*[]", true, "meshData");
 					meshsDataUV->add(meshData);
 
 					//メッシュのサイズを書き出す
-					if (part->type == SsPartType::mesh)
+					if (part->type == spritestudio6::SsPartType::mesh)
 					{
 						int meshsize = state->meshPart->ver_size;
 						meshData->add(Lump::s32Data((int)state->meshPart->isBind, "isBind"));	//バインドの有無
@@ -774,17 +774,17 @@ static Lump* parseParts(SsProject* proj, const std::string& imageBaseDir)
 				decoder.setPlayFrame(0);
 				decoder.update();
 
-				foreach(std::vector<SsPartAndAnime>, decoder.getPartAnime(), it)
+				SPRITESTUDIO6DSK_foreach(std::vector<spritestudio6::SsPartAndAnime>, decoder.getPartAnime(), it)
 				{
-					SsPart* part = it->first;
-					const SsPartState* state = findState(partList, part->arrayIndex);
+					spritestudio6::SsPart* part = it->first;
+					const spritestudio6::SsPartState* state = findState(partList, part->arrayIndex);
 
 					//サイズ分のUV出力
 					Lump* meshData = Lump::set("ss::ss_u16*[]", true, "meshData");
 					meshsDataIndices->add(meshData);
 
 					//メッシュのサイズを書き出す
-					if (part->type == SsPartType::mesh)
+					if (part->type == spritestudio6::SsPartType::mesh)
 					{
 						int tri_size = state->meshPart->tri_size;
 						meshData->add(Lump::s32Data(tri_size, "tri_size"));	//サイズ
@@ -838,11 +838,11 @@ static Lump* parseParts(SsProject* proj, const std::string& imageBaseDir)
 //				frameData->add(frameFlag);
 
 				int outPartsCount = 0;
-				foreach(std::list<SsPartState*>, partList, it)
+				SPRITESTUDIO6DSK_foreach(std::list<spritestudio6::SsPartState*>, partList, it)
 				{
-					const SsPartState* state = *it;
+					const spritestudio6::SsPartState* state = *it;
 					//セルに設定された原点補正を取得
-					SsVector2 pivot;
+					spritestudio6::SsVector2 pivot;
 					pivot.x = 0;
 					pivot.y = 0;
 					//セルの原点情報はセル情報へ含める
@@ -947,7 +947,7 @@ static Lump* parseParts(SsProject* proj, const std::string& imageBaseDir)
 					{
 						switch (state->partsColorValue.target)
 						{
-							case SsColorBlendTarget::whole:
+							case spritestudio6::SsColorBlendTarget::whole:
 								if ( 
 									  ( state->partsColorValue.color.rgba.a == 0 )
 								   && ( state->partsColorValue.color.rgba.r == 0 )
@@ -965,7 +965,7 @@ static Lump* parseParts(SsProject* proj, const std::string& imageBaseDir)
 								}
 
 								break;
-							case SsColorBlendTarget::vertex:
+							case spritestudio6::SsColorBlendTarget::vertex:
 								cb_flags = VERTEX_FLAG_LT|VERTEX_FLAG_RT|VERTEX_FLAG_LB|VERTEX_FLAG_RB;
 								break;
 							default:
@@ -1012,7 +1012,7 @@ static Lump* parseParts(SsProject* proj, const std::string& imageBaseDir)
 
 					int p_flags2 = 0;
 					//メッシュ情報を出力する必要があるかチェックする
-					if (state->partType == SsPartType::mesh)
+					if (state->partType == spritestudio6::SsPartType::mesh)
 					{
 						p_flags2 |= PART_FLAG_MESHDATA;
 					}
@@ -1192,8 +1192,8 @@ static Lump* parseParts(SsProject* proj, const std::string& imageBaseDir)
 								}
 								else
 								{
-									frameData->add(Lump::floatData((int)state->vertexValue.offsets[vtxNo].x, tagname_x));
-									frameData->add(Lump::floatData((int)state->vertexValue.offsets[vtxNo].y, tagname_y));
+									frameData->add(Lump::floatData((float)((int)state->vertexValue.offsets[vtxNo].x), tagname_x));
+									frameData->add(Lump::floatData((float)((int)state->vertexValue.offsets[vtxNo].y), tagname_y));
 								}
 							}
 						}
@@ -1261,16 +1261,16 @@ static Lump* parseParts(SsProject* proj, const std::string& imageBaseDir)
 				Lump* userData = Lump::set("ss::ss_u16[]", true, "userData");
 				int partsCount = 0;
 
-				foreach(std::vector<SsPartAndAnime>, decoder.getPartAnime(), it)
+				SPRITESTUDIO6DSK_foreach(std::vector<spritestudio6::SsPartAndAnime>, decoder.getPartAnime(), it)
 				{
-					SsPart* part = it->first;
-					SsPartAnime* partAnime = it->second;
+					spritestudio6::SsPart* part = it->first;
+					spritestudio6::SsPartAnime* partAnime = it->second;
 					if (!partAnime) continue;
 
-					foreach(SsAttributeList, partAnime->attributes, attrIt)
+					SPRITESTUDIO6DSK_foreach(spritestudio6::SsAttributeList, partAnime->attributes, attrIt)
 					{
-						SsAttribute* attr = *attrIt;
-						if (attr->tag != SsAttributeKind::user) continue;
+						spritestudio6::SsAttribute* attr = *attrIt;
+						if (attr->tag != spritestudio6::SsAttributeKind::user) continue;
 
 						// このフレームのデータを含む?
 						if (attr->key_dic.find(frame) != attr->key_dic.end())
@@ -1278,8 +1278,8 @@ static Lump* parseParts(SsProject* proj, const std::string& imageBaseDir)
 							hasUserData = true;
 							partsCount++;
 							
-							const SsKeyframe* keyframe = attr->key_dic.at(frame);
-							SsUserDataAnime udat;
+							const spritestudio6::SsKeyframe* keyframe = attr->key_dic.at(frame);
+							spritestudio6::SsUserDataAnime udat;
 							GetSsUserDataAnime(keyframe, udat);
 
 							int flags = 0;
@@ -1309,7 +1309,7 @@ static Lump* parseParts(SsProject* proj, const std::string& imageBaseDir)
 							}
 							if (udat.useString)
 							{
-								const SsString& str = udat.string;
+								const spritestudio6::SsString& str = udat.string;
 								userData->add(Lump::s16Data((int)str.length(), "str_length"));
 								userData->add(Lump::stringData(str, "str"));
 							}
@@ -1339,7 +1339,7 @@ static Lump* parseParts(SsProject* proj, const std::string& imageBaseDir)
 			{
 				Lump* labelData = Lump::set("ss::ss_u16[]", true, "labelData");
 
-				SsString str;
+				spritestudio6::SsString str;
 				str = anime->labels[label_idx]->name;
 				//全角チェック
 				if ( isZenkaku( &str ) == true )
@@ -1374,8 +1374,8 @@ static Lump* parseParts(SsProject* proj, const std::string& imageBaseDir)
 			animeData->add(Lump::s16Data(decoder.getAnimeTotalFrame(), "totalFrames"));
 			animeData->add(Lump::s16Data(anime->settings.fps, "fps"));
 			animeData->add(Lump::s16Data(label_idx, "labelNum"));							//ラベルデータ数
-			animeData->add(Lump::s16Data(anime->settings.canvasSize.x, "canvasSizeW"));		//基準枠W
-			animeData->add(Lump::s16Data(anime->settings.canvasSize.y, "canvasSizeH"));		//基準枠H
+			animeData->add(Lump::s16Data((int)anime->settings.canvasSize.x, "canvasSizeW"));		//基準枠W
+			animeData->add(Lump::s16Data((int)anime->settings.canvasSize.y, "canvasSizeH"));		//基準枠H
 			animeData->add(Lump::s16Data(0, "reserved"));									//ダミーデータ
 			animeData->add(Lump::floatData(anime->settings.pivot.x, "canvasPvotX"));			//基準枠位置
 			animeData->add(Lump::floatData(anime->settings.pivot.y, "canvasPvotY"));			//基準枠位置
@@ -1388,10 +1388,10 @@ static Lump* parseParts(SsProject* proj, const std::string& imageBaseDir)
 		Lump* effectFile = Lump::set("ss::EffectFile", false, "EffectFile");
 		effectfileArray->add(effectFile);
 
-		const SsEffectFile* effectfile = proj->effectfileList[effectIndex];
+		const spritestudio6::SsEffectFile* effectfile = proj->effectfileList[effectIndex];
 		effectFile->add(Lump::stringData(effectfile->name, "name"));				//エフェクト名
 
-		const SsEffectModel *effectmodel = &effectfile->effectData;
+		const spritestudio6::SsEffectModel *effectmodel = &effectfile->effectData;
 		effectFile->add(Lump::s16Data(effectmodel->fps, "fps"));					//FPS
 
 		effectFile->add(Lump::s16Data(effectmodel->isLockRandSeed, "isLockRandSeed"));		//乱数を固定するかどうか
@@ -1415,29 +1415,29 @@ static Lump* parseParts(SsProject* proj, const std::string& imageBaseDir)
 			Lump* effectNode = Lump::set("ss::EffectNode", false, "EffectNode");
 			effectNodeArray->add(effectNode);
 
-			SsEffectNode *node = effectmodel->nodeList[nodeindex];
+			spritestudio6::SsEffectNode *node = effectmodel->nodeList[nodeindex];
 			int	arrayIndex = node->arrayIndex;				//通し番号
 			int	parentIndex = node->parentIndex;			//親の番号
-			SsEffectNodeType::_enum	type = node->type;		//ノードの種類
+			spritestudio6::SsEffectNodeType::_enum	type = node->type;		//ノードの種類
 			//			bool visible = = node->visible;					//エディター用
-			SsEffectBehavior behavior = node->behavior;		//動作パラメータ
-			SsRenderBlendType::_enum blendType = behavior.BlendType;	//描画方法
+			spritestudio6::SsEffectBehavior behavior = node->behavior;		//動作パラメータ
+			spritestudio6::SsRenderBlendType::_enum blendType = behavior.BlendType;	//描画方法
 			//セル番号
-			SsCell*	refCell = behavior.refCell;
+			spritestudio6::SsCell*	refCell = behavior.refCell;
 			int cellIndex = -1;
 			if (refCell)
 			{
 				cellIndex = (*cellList)[refCell];
 			}
-			SsString CellName = behavior.CellName;
-			SsString CellMapName = behavior.CellMapName;
+			spritestudio6::SsString CellName = behavior.CellName;
+			spritestudio6::SsString CellMapName = behavior.CellMapName;
 			//ファイルへ書き出し
 			effectNode->add(Lump::s16Data(arrayIndex, "arrayIndex"));		//通し番号
 			effectNode->add(Lump::s16Data(parentIndex, "parentIndex"));	//親の番号
 			effectNode->add(Lump::s16Data(type, "type"));			//ノードの種類
 			effectNode->add(Lump::s16Data(cellIndex, "cellIndex"));		//セルの番号
 			effectNode->add(Lump::s16Data(blendType, "blendType"));		//描画方法
-			effectNode->add(Lump::s16Data(behavior.plist.size(), "numBehavior"));	//コマンドパラメータ数
+			effectNode->add(Lump::s16Data((int)(behavior.plist.size()), "numBehavior"));	//コマンドパラメータ数
 
 			Lump* effectBehaviorArray = Lump::set("ss::ss_u16*[]", true, "effectBehaviorArray");
 			effectNode->add(effectBehaviorArray);			//コマンドパラメータ配列
@@ -1448,30 +1448,30 @@ static Lump* parseParts(SsProject* proj, const std::string& imageBaseDir)
 				Lump* effectBehavior = Lump::set("ss::ss_u16[]", true, "effectBehavior");
 				effectBehaviorArray->add(effectBehavior);
 
-				SsEffectElementBase *elementbase = behavior.plist[plistindex];
-				SsEffectFunctionType::enum_ myType = elementbase->myType;
+				spritestudio6::SsEffectElementBase *elementbase = behavior.plist[plistindex];
+				spritestudio6::SsEffectFunctionType::enum_ myType = elementbase->myType;
 				effectBehavior->add(Lump::s32Data(myType, "SsEffectFunctionType"));	//コマンドタイプ
 
 				switch (myType)
 				{
-				case SsEffectFunctionType::Basic:
+				case spritestudio6::SsEffectFunctionType::Basic:
 				{
 					//基本情報
-					ParticleElementBasic *element = (ParticleElementBasic*)elementbase;
+					spritestudio6::ParticleElementBasic *element = (spritestudio6::ParticleElementBasic*)elementbase;
 
-					int			maximumParticle = element->maximumParticle;
-					f32VValue	speed = element->speed;
-					i32VValue 	lifespan = element->lifespan;
-					float		angle = element->angle;
-					float		angleVariance = element->angleVariance;
-					int			interval = element->interval;
-					int			lifetime = element->lifetime;
-					int			attimeCreate = element->attimeCreate;
-					int			priority = element->priority;
-					float speedMinValue = speed.getMinValue();	//初速最小
-					float speedMaxValue = speed.getMaxValue();	//初速最大
-					int lifespanMinValue = lifespan.getMinValue();	//パーティクル生存時間最小
-					int lifespanMaxValue = lifespan.getMaxValue();	//パーティクル生存時間最大
+					int							maximumParticle = element->maximumParticle;
+					spritestudio6::f32VValue	speed = element->speed;
+					spritestudio6::i32VValue 	lifespan = element->lifespan;
+					float						angle = element->angle;
+					float						angleVariance = element->angleVariance;
+					int							interval = element->interval;
+					int							lifetime = element->lifetime;
+					int							attimeCreate = element->attimeCreate;
+					int							priority = element->priority;
+					float						speedMinValue = speed.getMinValue();	//初速最小
+					float						speedMaxValue = speed.getMaxValue();	//初速最大
+					int							lifespanMinValue = lifespan.getMinValue();	//パーティクル生存時間最小
+					int							lifespanMaxValue = lifespan.getMaxValue();	//パーティクル生存時間最大
 
 					effectBehavior->add(Lump::s32Data(priority, "priority"));				//表示優先度
 					effectBehavior->add(Lump::s32Data(maximumParticle, "maximumParticle"));		//最大パーティクル数
@@ -1486,118 +1486,118 @@ static Lump* parseParts(SsProject* proj, const std::string& imageBaseDir)
 					effectBehavior->add(Lump::floatData(angleVariance, "angleVariance"));		//射出方向範囲
 					break;
 				}
-				case SsEffectFunctionType::RndSeedChange:
+				case spritestudio6::SsEffectFunctionType::RndSeedChange:
 				{
 					//シード上書き
-					ParticleElementRndSeedChange *element = (ParticleElementRndSeedChange*)elementbase;
+					spritestudio6::ParticleElementRndSeedChange *element = (spritestudio6::ParticleElementRndSeedChange*)elementbase;
 					int		Seed = element->Seed;
 					effectBehavior->add(Lump::s32Data(Seed, "Seed"));					//上書きする値
 					break;
 				}
-				case SsEffectFunctionType::Delay:
+				case spritestudio6::SsEffectFunctionType::Delay:
 				{
 					//発生：タイミング
-					ParticleElementDelay *element = (ParticleElementDelay*)elementbase;
+					spritestudio6::ParticleElementDelay *element = (spritestudio6::ParticleElementDelay*)elementbase;
 					int		DelayTime = element->DelayTime;
 					effectBehavior->add(Lump::s32Data(DelayTime, "DelayTime"));				//遅延時間
 					break;
 				}
-				case SsEffectFunctionType::Gravity:
+				case spritestudio6::SsEffectFunctionType::Gravity:
 				{
 					//重力を加える
-					ParticleElementGravity *element = (ParticleElementGravity*)elementbase;
-					SsVector2   Gravity = element->Gravity;
+					spritestudio6::ParticleElementGravity *element = (spritestudio6::ParticleElementGravity*)elementbase;
+					spritestudio6::SsVector2   Gravity = element->Gravity;
 					effectBehavior->add(Lump::floatData(Gravity.x, "Gravity_x"));				//X方向の重力
 					effectBehavior->add(Lump::floatData(Gravity.y, "Gravity_y"));				//Y方向の重力
 					break;
 				}
-				case SsEffectFunctionType::Position:
+				case spritestudio6::SsEffectFunctionType::Position:
 				{
 					//座標：生成時
-					ParticleElementPosition *element = (ParticleElementPosition*)elementbase;
-					f32VValue   OffsetX = element->OffsetX;
-					f32VValue   OffsetY = element->OffsetY;
+					spritestudio6::ParticleElementPosition *element = (spritestudio6::ParticleElementPosition*)elementbase;
+					spritestudio6::f32VValue OffsetX = element->OffsetX;
+					spritestudio6::f32VValue OffsetY = element->OffsetY;
 					effectBehavior->add(Lump::floatData(OffsetX.getMinValue(), "OffsetXMinValue"));				//X座標に加算最小
 					effectBehavior->add(Lump::floatData(OffsetX.getMaxValue(), "OffsetXMaxValue"));				//X座標に加算最大
 					effectBehavior->add(Lump::floatData(OffsetY.getMinValue(), "OffsetYMinValue"));				//X座標に加算最小
 					effectBehavior->add(Lump::floatData(OffsetY.getMaxValue(), "OffsetYMaxValue"));				//X座標に加算最大
 					break;
 				}
-				case SsEffectFunctionType::Rotation:
+				case spritestudio6::SsEffectFunctionType::Rotation:
 				{
 					//Z回転を追加
-					ParticleElementRotation *element = (ParticleElementRotation*)elementbase;
-					f32VValue   Rotation = element->Rotation;
-					f32VValue   RotationAdd = element->RotationAdd;
+					spritestudio6::ParticleElementRotation *element = (spritestudio6::ParticleElementRotation*)elementbase;
+					spritestudio6::f32VValue Rotation = element->Rotation;
+					spritestudio6::f32VValue RotationAdd = element->RotationAdd;
 					effectBehavior->add(Lump::floatData(Rotation.getMinValue(), "RotationMinValue"));			//角度初期値最小
 					effectBehavior->add(Lump::floatData(Rotation.getMaxValue(), "RotationMaxValue"));			//角度初期値最大
 					effectBehavior->add(Lump::floatData(RotationAdd.getMinValue(), "RotationAddMinValue"));			//角度初期加算値最小
 					effectBehavior->add(Lump::floatData(RotationAdd.getMaxValue(), "RotationAddMaxValue"));			//角度初期加算値最大
 					break;
 				}
-				case SsEffectFunctionType::TransRotation:
+				case spritestudio6::SsEffectFunctionType::TransRotation:
 				{
 					//Z回転速度変更
-					ParticleElementRotationTrans *element = (ParticleElementRotationTrans*)elementbase;
+					spritestudio6::ParticleElementRotationTrans *element = (spritestudio6::ParticleElementRotationTrans*)elementbase;
 					float   RotationFactor = element->RotationFactor;
 					float	EndLifeTimePer = element->EndLifeTimePer;
 					effectBehavior->add(Lump::floatData(RotationFactor, "RotationFactor"));					//角度目標加算値
 					effectBehavior->add(Lump::floatData(EndLifeTimePer, "EndLifeTimePer"));					//到達時間
 					break;
 				}
-				case SsEffectFunctionType::TransSpeed:
+				case spritestudio6::SsEffectFunctionType::TransSpeed:
 				{
 					//速度：変化
-					ParticleElementTransSpeed *element = (ParticleElementTransSpeed*)elementbase;
-					f32VValue	Speed = element->Speed;
+					spritestudio6::ParticleElementTransSpeed *element = (spritestudio6::ParticleElementTransSpeed*)elementbase;
+					spritestudio6::f32VValue Speed = element->Speed;
 					effectBehavior->add(Lump::floatData(Speed.getMinValue(), "SpeedMinValue"));				//速度目標値最小
 					effectBehavior->add(Lump::floatData(Speed.getMaxValue(), "SpeedMaxValue"));				//速度目標値最大
 					break;
 				}
-				case SsEffectFunctionType::TangentialAcceleration:
+				case spritestudio6::SsEffectFunctionType::TangentialAcceleration:
 				{
 					//接線加速度
-					ParticleElementTangentialAcceleration *element = (ParticleElementTangentialAcceleration*)elementbase;
-					f32VValue	Acceleration = element->Acceleration;
+					spritestudio6::ParticleElementTangentialAcceleration *element = (spritestudio6::ParticleElementTangentialAcceleration*)elementbase;
+					spritestudio6::f32VValue Acceleration = element->Acceleration;
 
 					effectBehavior->add(Lump::floatData(Acceleration.getMinValue(), "AccelerationMinValue"));		//設定加速度最小
 					effectBehavior->add(Lump::floatData(Acceleration.getMaxValue(), "AccelerationMaxValue"));		//設定加速度最大
 					break;
 				}
-				case SsEffectFunctionType::InitColor:
+				case spritestudio6::SsEffectFunctionType::InitColor:
 				{
 					//カラーRGBA：生成時
-					ParticleElementInitColor *element = (ParticleElementInitColor*)elementbase;
-					SsU8cVValue Color = element->Color;
+					spritestudio6::ParticleElementInitColor *element = (spritestudio6::ParticleElementInitColor*)elementbase;
+					spritestudio6::SsU8cVValue Color = element->Color;
 					effectBehavior->add(Lump::s32Data(Color.getMinValue().toARGB(), "ColorMinValue"));		//設定カラー最小
 					effectBehavior->add(Lump::s32Data(Color.getMaxValue().toARGB(), "ColorMaxValue"));		//設定カラー最大
 					break;
 				}
-				case SsEffectFunctionType::TransColor:
+				case spritestudio6::SsEffectFunctionType::TransColor:
 				{
 					//カラーRGB：変化
-					ParticleElementTransColor *element = (ParticleElementTransColor*)elementbase;
-					SsU8cVValue Color = element->Color;
+					spritestudio6::ParticleElementTransColor *element = (spritestudio6::ParticleElementTransColor*)elementbase;
+					spritestudio6::SsU8cVValue Color = element->Color;
 					effectBehavior->add(Lump::s32Data(Color.getMinValue().toARGB(), "ColorMinValue"));		//設定カラー最小
 					effectBehavior->add(Lump::s32Data(Color.getMaxValue().toARGB(), "ColorMaxValue"));		//設定カラー最大
 					break;
 				}
-				case SsEffectFunctionType::AlphaFade:
+				case spritestudio6::SsEffectFunctionType::AlphaFade:
 				{
 					//フェード
-					ParticleElementAlphaFade *element = (ParticleElementAlphaFade*)elementbase;
-					f32VValue  disprange = element->disprange; // mnagaku 頭小文字
+					spritestudio6::ParticleElementAlphaFade *element = (spritestudio6::ParticleElementAlphaFade*)elementbase;
+					spritestudio6::f32VValue  disprange = element->disprange; // mnagaku 頭小文字
 					effectBehavior->add(Lump::floatData(disprange.getMinValue(), "disprangeMinValue"));			//表示区間開始
 					effectBehavior->add(Lump::floatData(disprange.getMaxValue(), "disprangeMaxValue"));			//表示区間終了
 					break;
 				}
-				case SsEffectFunctionType::Size:
+				case spritestudio6::SsEffectFunctionType::Size:
 				{
 					//スケール：生成時
-					ParticleElementSize *element = (ParticleElementSize*)elementbase;
-					f32VValue SizeX = element->SizeX;
-					f32VValue SizeY = element->SizeY;
-					f32VValue ScaleFactor = element->ScaleFactor;
+					spritestudio6::ParticleElementSize *element = (spritestudio6::ParticleElementSize*)elementbase;
+					spritestudio6::f32VValue SizeX = element->SizeX;
+					spritestudio6::f32VValue SizeY = element->SizeY;
+					spritestudio6::f32VValue ScaleFactor = element->ScaleFactor;
 					effectBehavior->add(Lump::floatData(SizeX.getMinValue(), "SizeXMinValue"));				//幅倍率最小
 					effectBehavior->add(Lump::floatData(SizeX.getMaxValue(), "SizeXMaxValue"));				//幅倍率最大
 					effectBehavior->add(Lump::floatData(SizeY.getMinValue(), "SizeYMinValue"));				//高さ倍率最小
@@ -1606,13 +1606,13 @@ static Lump* parseParts(SsProject* proj, const std::string& imageBaseDir)
 					effectBehavior->add(Lump::floatData(ScaleFactor.getMaxValue(), "ScaleFactorMaxValue"));			//倍率最大
 					break;
 				}
-				case SsEffectFunctionType::TransSize:
+				case spritestudio6::SsEffectFunctionType::TransSize:
 				{
 					//スケール：変化
-					ParticleElementTransSize *element = (ParticleElementTransSize*)elementbase;
-					f32VValue SizeX = element->SizeX;
-					f32VValue SizeY = element->SizeY;
-					f32VValue ScaleFactor = element->ScaleFactor;
+					spritestudio6::ParticleElementTransSize *element = (spritestudio6::ParticleElementTransSize*)elementbase;
+					spritestudio6::f32VValue SizeX = element->SizeX;
+					spritestudio6::f32VValue SizeY = element->SizeY;
+					spritestudio6::f32VValue ScaleFactor = element->ScaleFactor;
 					effectBehavior->add(Lump::floatData(SizeX.getMinValue(), "SizeXMinValue"));				//幅倍率最小
 					effectBehavior->add(Lump::floatData(SizeX.getMaxValue(), "SizeXMaxValue"));				//幅倍率最大
 					effectBehavior->add(Lump::floatData(SizeY.getMinValue(), "SizeYMinValue"));				//高さ倍率最小
@@ -1621,34 +1621,34 @@ static Lump* parseParts(SsProject* proj, const std::string& imageBaseDir)
 					effectBehavior->add(Lump::floatData(ScaleFactor.getMaxValue(), "ScaleFactorMaxValue"));			//倍率最大
 					break;
 				}
-				case SsEffectFunctionType::PointGravity:
+				case spritestudio6::SsEffectFunctionType::PointGravity:
 				{
 					//重力点の追加
-					ParticlePointGravity *element = (ParticlePointGravity*)elementbase;
-					SsVector2   Position = element->Position;
+					spritestudio6::ParticlePointGravity *element = (spritestudio6::ParticlePointGravity*)elementbase;
+					spritestudio6::SsVector2   Position = element->Position;
 					float		Power = element->Power;
 					effectBehavior->add(Lump::floatData(Position.x, "Position_x"));						//重力点X
 					effectBehavior->add(Lump::floatData(Position.y, "Position_y"));						//重力点Y
 					effectBehavior->add(Lump::floatData(Power, "Power"));							//パワー
 					break;
 				}
-				case SsEffectFunctionType::TurnToDirectionEnabled:
+				case spritestudio6::SsEffectFunctionType::TurnToDirectionEnabled:
 				{
 					//進行方向に向ける
-					ParticleTurnToDirectionEnabled *element = (ParticleTurnToDirectionEnabled*)elementbase;
+					spritestudio6::ParticleTurnToDirectionEnabled *element = (spritestudio6::ParticleTurnToDirectionEnabled*)elementbase;
 					//コマンドがあれば有効
 					effectBehavior->add(Lump::floatData(element->Rotation, "Rotation"));				//方向オフセット
 					break;
 				}
-				case SsEffectFunctionType::InfiniteEmitEnabled:
+				case spritestudio6::SsEffectFunctionType::InfiniteEmitEnabled:
 				{
 					//無限にする
-					ParticleInfiniteEmitEnabled *element = (ParticleInfiniteEmitEnabled*)elementbase;
+					spritestudio6::ParticleInfiniteEmitEnabled *element = (spritestudio6::ParticleInfiniteEmitEnabled*)elementbase;
 					//コマンドがあれば有効
 					effectBehavior->add(Lump::s32Data(1, "flag"));									//ダミーデータ
 					break;
 				}
-				case SsEffectFunctionType::Base:
+				case spritestudio6::SsEffectFunctionType::Base:
 				default:
 					//未使用のコマンドが含まれている
 					std::cerr << "警告：未使用のエフェクトコマンドが含まれています。 \n";
@@ -1671,9 +1671,9 @@ static Lump* parseParts(SsProject* proj, const std::string& imageBaseDir)
 void convertProject(const std::string& outPath, LumpExporter::StringEncoding encoding, const std::string& sspjPath,
 	const std::string& imageBaseDir, const std::string& creatorComment, const int outputFormat)
 {
-	SSTextureFactory texFactory(new SSTextureBMP());
+	spritestudio6::SSTextureFactory texFactory(new spritestudio6::SSTextureBMP());
 	std::cerr << sspjPath << "\n";
-	SsProject* proj = ssloader_sspj::Load(sspjPath);
+	spritestudio6::SsProject* proj = spritestudio6::ssloader_sspj::Load(sspjPath);
 	Lump* lump;
 	try
 	{
@@ -2003,9 +2003,9 @@ int convertMain(int argc, const char * argv[])
 			//パスが指定されている場合
 			int st = 0;
 #ifdef _WIN32
-			st = outPath.find_last_of("\\");
+			st = (int)(outPath.find_last_of("\\"));
 #else
-            st = outPath.find_last_of("/");
+            st = (int)(outPath.find_last_of("/"));
 #endif
 			std::string ssbpname = outPath.substr(st+1);
 

--- a/Build/Viewer2/Source/Model/Player.h
+++ b/Build/Viewer2/Source/Model/Player.h
@@ -11,11 +11,16 @@
 #pragma once
 #include "../JuceLibraryCode/JuceHeader.h"
 
-class SsProject;
-class SsAnimePack;
-class SsAnimeDecoder;
-class SsCellMapList;
-class SSTextureFactory;
+// class SsProject;
+// class SsAnimePack;
+// class SsAnimeDecoder;
+// class SsCellMapList;
+// class SSTextureFactory;
+class spritestudio6::SsProject;
+class spritestudio6::SsAnimePack;
+class spritestudio6::SsAnimeDecoder;
+class spritestudio6::SsCellMapList;
+class spritestudio6::SSTextureFactory;
 
 class Player : public juce::HighResolutionTimer
 {
@@ -117,13 +122,16 @@ public:
 	static void	drawAnime();
 
 	// アニメーションの状態
-	std::unique_ptr<StatePlaying>		statePlaying;
-	std::unique_ptr<StatePaused>		statePaused;
-	std::unique_ptr<StateLoading>		stateLoading;
-	std::unique_ptr<StateInitial>		stateInitial;
-	std::unique_ptr<SsProject>			currentProj;
-	std::unique_ptr<SsAnimeDecoder>		decoder;
-	SsCellMapList *						cellmap = nullptr; // decoderのデストラクタでdeleteされる
+	std::unique_ptr<StatePlaying>					statePlaying;
+	std::unique_ptr<StatePaused>					statePaused;
+	std::unique_ptr<StateLoading>					stateLoading;
+	std::unique_ptr<StateInitial>					stateInitial;
+//	std::unique_ptr<SsProject>		currentProj;
+//	std::unique_ptr<SsAnimeDecoder>	decoder;
+//	SsCellMapList *					cellmap = nullptr; // decoderのデストラクタでdeleteされる
+	std::unique_ptr<spritestudio6::SsProject>		currentProj;
+	std::unique_ptr<spritestudio6::SsAnimeDecoder>	decoder;
+	spritestudio6::SsCellMapList *					cellmap = nullptr; // decoderのデストラクタでdeleteされる
 
 	friend class AsyncAnimeLoader;
 	friend class AsyncProjectLoader;

--- a/Build/Viewer2/Source/Model/Player.h
+++ b/Build/Viewer2/Source/Model/Player.h
@@ -11,16 +11,11 @@
 #pragma once
 #include "../JuceLibraryCode/JuceHeader.h"
 
-// class SsProject;
-// class SsAnimePack;
-// class SsAnimeDecoder;
-// class SsCellMapList;
-// class SSTextureFactory;
-class spritestudio6::SsProject;
-class spritestudio6::SsAnimePack;
-class spritestudio6::SsAnimeDecoder;
-class spritestudio6::SsCellMapList;
-class spritestudio6::SSTextureFactory;
+class SsProject;
+class SsAnimePack;
+class SsAnimeDecoder;
+class SsCellMapList;
+class SSTextureFactory;
 
 class Player : public juce::HighResolutionTimer
 {
@@ -122,16 +117,13 @@ public:
 	static void	drawAnime();
 
 	// アニメーションの状態
-	std::unique_ptr<StatePlaying>					statePlaying;
-	std::unique_ptr<StatePaused>					statePaused;
-	std::unique_ptr<StateLoading>					stateLoading;
-	std::unique_ptr<StateInitial>					stateInitial;
-//	std::unique_ptr<SsProject>		currentProj;
-//	std::unique_ptr<SsAnimeDecoder>	decoder;
-//	SsCellMapList *					cellmap = nullptr; // decoderのデストラクタでdeleteされる
-	std::unique_ptr<spritestudio6::SsProject>		currentProj;
-	std::unique_ptr<spritestudio6::SsAnimeDecoder>	decoder;
-	spritestudio6::SsCellMapList *					cellmap = nullptr; // decoderのデストラクタでdeleteされる
+	std::unique_ptr<StatePlaying>	statePlaying;
+	std::unique_ptr<StatePaused>	statePaused;
+	std::unique_ptr<StateLoading>	stateLoading;
+	std::unique_ptr<StateInitial>	stateInitial;
+	std::unique_ptr<SsProject>		currentProj;
+	std::unique_ptr<SsAnimeDecoder>	decoder;
+	SsCellMapList *					cellmap = nullptr; // decoderのデストラクタでdeleteされる
 
 	friend class AsyncAnimeLoader;
 	friend class AsyncProjectLoader;

--- a/Common/Animator/ISsEffectRender.h
+++ b/Common/Animator/ISsEffectRender.h
@@ -1,6 +1,8 @@
 ﻿#ifndef __ISSEFFECTRENDER__
 #define __ISSEFFECTRENDER__
 
+namespace spritestudio6
+{
 
 class SsPartState;
 class SsEffectModel;
@@ -44,5 +46,6 @@ public:
 
 };
 
+}	// namespace spritestudio6
 
 #endif

--- a/Common/Animator/ssplayer_PartState.cpp
+++ b/Common/Animator/ssplayer_PartState.cpp
@@ -2,6 +2,10 @@
 #include "ssplayer_animedecode.h"
 #include "ssplayer_PartState.h"
 
+namespace spritestudio6
+{
+
+
 SsPartState::SsPartState() : refAnime(0), index(-1), parent(nullptr), noCells(false), alphaBlendType(SsBlendType::invalid),	refEffect(0) , 	meshPart(0)
 {
 	init();
@@ -115,3 +119,5 @@ void	SsPartState::reset()
 	effectValue.startTime = 0;
 
 }
+
+}	// namespace spritestudio6

--- a/Common/Animator/ssplayer_PartState.h
+++ b/Common/Animator/ssplayer_PartState.h
@@ -5,6 +5,9 @@
 //#include "../Helper/ssHelper.h"
 
 
+namespace spritestudio6
+{
+
 class SsAnimeDecoder;
 //class SsEffectRenderer;
 class SsEffectRenderV2;
@@ -100,5 +103,6 @@ struct SsPartState
 };
 
 
+}	//	namespace spritestudio6
 
 #endif

--- a/Common/Animator/ssplayer_animedecode.cpp
+++ b/Common/Animator/ssplayer_animedecode.cpp
@@ -11,6 +11,9 @@
 #include "ssplayer_mesh.h"
 #include "ssInterpolation.h"
 
+namespace spritestudio6
+{
+
 //stdでののforeach宣言　
 
 //乱数シードに利用するユニークIDを作成します。
@@ -47,7 +50,7 @@ SsAnimeDecoder::SsAnimeDecoder() :
 
 void	SsAnimeDecoder::reset()
 {
-	foreach( std::list<SsPartState*> , sortList , e )
+	SPRITESTUDIO6DSK_foreach( std::list<SsPartState*> , sortList , e )
 	{
 		SsPartState* state = (*e);
 		if ( state->refEffect )
@@ -64,7 +67,7 @@ void	SsAnimeDecoder::reset()
 void	SsAnimeDecoder::restart()
 {
 #if 0
-	foreach( std::list<SsPartState*> , sortList , e )
+	SPRITESTUDIO6DSK_foreach( std::list<SsPartState*> , sortList , e )
 	{
 		SsPartState* state = (*e);
 		if ( state->refEffect )
@@ -88,7 +91,7 @@ bool	SsAnimeDecoder::getFirstCell(SsPart* part , SsCellValue& out)
 		SsAttributeList attList;
 		attList = setupAnime->attributes;
 
-		foreach(SsAttributeList, attList, e)
+		SPRITESTUDIO6DSK_foreach(SsAttributeList, attList, e)
 		{
 			SsAttribute* attr = (*e);
 			switch (attr->tag)
@@ -183,7 +186,7 @@ void	SsAnimeDecoder::setAnimation( SsModel*	model , SsAnimation* anime , SsCellM
 
 		//継承率の設定
 		partState[i].inheritRates = p->inheritRates;
-		partState[i].index = i;
+		partState[i].index = (int)i;
 		partState[i].partType = p->type;
 		partState[i].maskInfluence = p->maskInfluence && getMaskParentSetting();
 
@@ -313,8 +316,8 @@ void	SsAnimeDecoder::SsInterpolationValue( int time , const SsKeyframe* leftkey 
 	if (leftkey->ipType == SsInterpolationType::bezier)
 	{
 		// ベジェのみキーの開始・終了時間が必要
-		curve.startKeyTime = leftkey->time;
-		curve.endKeyTime = rightkey->time;
+		curve.startKeyTime = (float)leftkey->time;
+		curve.endKeyTime = (float)rightkey->time;
 	}
 	
 	float rate = SsInterpolate( leftkey->ipType , now , 0.0f , 1.0f , &curve );	
@@ -362,8 +365,8 @@ void	SsAnimeDecoder::SsInterpolationValue(int time, const SsKeyframe* leftkey, c
 	if (leftkey->ipType == SsInterpolationType::bezier)
 	{
 		// ベジェのみキーの開始・終了時間が必要
-		curve.startKeyTime = leftkey->time;
-		curve.endKeyTime = rightkey->time;
+		curve.startKeyTime = (float)leftkey->time;
+		curve.endKeyTime = (float)rightkey->time;
 	}
 
 	int range = rightkey->time - leftkey->time;
@@ -387,10 +390,10 @@ void	SsAnimeDecoder::SsInterpolationValue(int time, const SsKeyframe* leftkey, c
 			for (int i = 0; i < 4; i++)
 			{
 				v.colors[i].rate = clamp(SsInterpolate(SsInterpolationType::linear, now, leftv.colors[i].rate, rightv.colors[i].rate, &curve), 0.0f, 1.0f);
-				v.colors[i].rgba.a = clamp(SsInterpolate(SsInterpolationType::linear, now, leftv.colors[i].rgba.a, rightv.colors[i].rgba.a, &curve), 0.0f, 255.0f);
-				v.colors[i].rgba.r = clamp(SsInterpolate(SsInterpolationType::linear, now, leftv.colors[i].rgba.r, rightv.colors[i].rgba.r, &curve), 0.0f, 255.0f);
-				v.colors[i].rgba.g = clamp(SsInterpolate(SsInterpolationType::linear, now, leftv.colors[i].rgba.g, rightv.colors[i].rgba.g, &curve), 0.0f, 255.0f);
-				v.colors[i].rgba.b = clamp(SsInterpolate(SsInterpolationType::linear, now, leftv.colors[i].rgba.b, rightv.colors[i].rgba.b, &curve), 0.0f, 255.0f);
+				v.colors[i].rgba.a = (u32)(clamp(SsInterpolate(SsInterpolationType::linear, now, (float)leftv.colors[i].rgba.a, (float)rightv.colors[i].rgba.a, &curve), 0.0f, 255.0f));
+				v.colors[i].rgba.r = (u32)(clamp(SsInterpolate(SsInterpolationType::linear, now, (float)leftv.colors[i].rgba.r, (float)rightv.colors[i].rgba.r, &curve), 0.0f, 255.0f));
+				v.colors[i].rgba.g = (u32)(clamp(SsInterpolate(SsInterpolationType::linear, now, (float)leftv.colors[i].rgba.g, (float)rightv.colors[i].rgba.g, &curve), 0.0f, 255.0f));
+				v.colors[i].rgba.b = (u32)(clamp(SsInterpolate(SsInterpolationType::linear, now, (float)leftv.colors[i].rgba.b, (float)rightv.colors[i].rgba.b, &curve), 0.0f, 255.0f));
 			}
 		}
 		else
@@ -399,10 +402,10 @@ void	SsAnimeDecoder::SsInterpolationValue(int time, const SsKeyframe* leftkey, c
 			for (int i = 0; i < 4; i++)
 			{
 				v.colors[i].rate = clamp(SsInterpolate(SsInterpolationType::linear, now, leftv.colors[i].rate, rightv.color.rate, &curve), 0.0f, 1.0f);
-				v.colors[i].rgba.a = clamp(SsInterpolate(SsInterpolationType::linear, now, leftv.colors[i].rgba.a, rightv.color.rgba.a, &curve), 0.0f, 255.0f);
-				v.colors[i].rgba.r = clamp(SsInterpolate(SsInterpolationType::linear, now, leftv.colors[i].rgba.r, rightv.color.rgba.r, &curve), 0.0f, 255.0f);
-				v.colors[i].rgba.g = clamp(SsInterpolate(SsInterpolationType::linear, now, leftv.colors[i].rgba.g, rightv.color.rgba.g, &curve), 0.0f, 255.0f);
-				v.colors[i].rgba.b = clamp(SsInterpolate(SsInterpolationType::linear, now, leftv.colors[i].rgba.b, rightv.color.rgba.b, &curve), 0.0f, 255.0f);
+				v.colors[i].rgba.a = (u32)(clamp(SsInterpolate(SsInterpolationType::linear, now, (float)leftv.colors[i].rgba.a, (float)rightv.color.rgba.a, &curve), 0.0f, 255.0f));
+				v.colors[i].rgba.r = (u32)(clamp(SsInterpolate(SsInterpolationType::linear, now, (float)leftv.colors[i].rgba.r, (float)rightv.color.rgba.r, &curve), 0.0f, 255.0f));
+				v.colors[i].rgba.g = (u32)(clamp(SsInterpolate(SsInterpolationType::linear, now, (float)leftv.colors[i].rgba.g, (float)rightv.color.rgba.g, &curve), 0.0f, 255.0f));
+				v.colors[i].rgba.b = (u32)(clamp(SsInterpolate(SsInterpolationType::linear, now, (float)leftv.colors[i].rgba.b, (float)rightv.color.rgba.b, &curve), 0.0f, 255.0f));
 			}
 		}
 	}
@@ -414,20 +417,20 @@ void	SsAnimeDecoder::SsInterpolationValue(int time, const SsKeyframe* leftkey, c
 			for (int i = 0; i < 4; i++)
 			{
 				v.colors[i].rate = clamp(SsInterpolate(SsInterpolationType::linear, now, leftv.color.rate, rightv.colors[i].rate, &curve), 0.0f, 1.0f);
-				v.colors[i].rgba.a = clamp(SsInterpolate(SsInterpolationType::linear, now, leftv.color.rgba.a, rightv.colors[i].rgba.a, &curve), 0.0f, 255.0f);
-				v.colors[i].rgba.r = clamp(SsInterpolate(SsInterpolationType::linear, now, leftv.color.rgba.r, rightv.colors[i].rgba.r, &curve), 0.0f, 255.0f);
-				v.colors[i].rgba.g = clamp(SsInterpolate(SsInterpolationType::linear, now, leftv.color.rgba.g, rightv.colors[i].rgba.g, &curve), 0.0f, 255.0f);
-				v.colors[i].rgba.b = clamp(SsInterpolate(SsInterpolationType::linear, now, leftv.color.rgba.b, rightv.colors[i].rgba.b, &curve), 0.0f, 255.0f);
+				v.colors[i].rgba.a = (u32)(clamp(SsInterpolate(SsInterpolationType::linear, now, (float)leftv.color.rgba.a, (float)rightv.colors[i].rgba.a, &curve), 0.0f, 255.0f));
+				v.colors[i].rgba.r = (u32)(clamp(SsInterpolate(SsInterpolationType::linear, now, (float)leftv.color.rgba.r, (float)rightv.colors[i].rgba.r, &curve), 0.0f, 255.0f));
+				v.colors[i].rgba.g = (u32)(clamp(SsInterpolate(SsInterpolationType::linear, now, (float)leftv.color.rgba.g, (float)rightv.colors[i].rgba.g, &curve), 0.0f, 255.0f));
+				v.colors[i].rgba.b = (u32)(clamp(SsInterpolate(SsInterpolationType::linear, now, (float)leftv.color.rgba.b, (float)rightv.colors[i].rgba.b, &curve), 0.0f, 255.0f));
 			}
 		}
 		else
 		{
 			//両方とも単色
 			v.color.rate = clamp(SsInterpolate(SsInterpolationType::linear, now, leftv.color.rate, rightv.color.rate, &curve), 0.0f, 1.0f);
-			v.color.rgba.a = clamp(SsInterpolate(SsInterpolationType::linear, now, leftv.color.rgba.a, rightv.color.rgba.a, &curve), 0.0f, 255.0f);
-			v.color.rgba.r = clamp(SsInterpolate(SsInterpolationType::linear, now, leftv.color.rgba.r, rightv.color.rgba.r, &curve), 0.0f, 255.0f);
-			v.color.rgba.g = clamp(SsInterpolate(SsInterpolationType::linear, now, leftv.color.rgba.g, rightv.color.rgba.g, &curve), 0.0f, 255.0f);
-			v.color.rgba.b = clamp(SsInterpolate(SsInterpolationType::linear, now, leftv.color.rgba.b, rightv.color.rgba.b, &curve), 0.0f, 255.0f);
+			v.color.rgba.a = (u32)(clamp(SsInterpolate(SsInterpolationType::linear, now, (float)leftv.color.rgba.a, (float)rightv.color.rgba.a, &curve), 0.0f, 255.0f));
+			v.color.rgba.r = (u32)(clamp(SsInterpolate(SsInterpolationType::linear, now, (float)leftv.color.rgba.r, (float)rightv.color.rgba.r, &curve), 0.0f, 255.0f));
+			v.color.rgba.g = (u32)(clamp(SsInterpolate(SsInterpolationType::linear, now, (float)leftv.color.rgba.g, (float)rightv.color.rgba.g, &curve), 0.0f, 255.0f));
+			v.color.rgba.b = (u32)(clamp(SsInterpolate(SsInterpolationType::linear, now, (float)leftv.color.rgba.b, (float)rightv.color.rgba.b, &curve), 0.0f, 255.0f));
 			v.target = SsColorBlendTarget::whole;
 		}
 	}
@@ -455,8 +458,8 @@ void	SsAnimeDecoder::SsInterpolationValue( int time , const SsKeyframe* leftkey 
 	if (leftkey->ipType == SsInterpolationType::bezier)
 	{
 		// ベジェのみキーの開始・終了時間が必要
-		curve.startKeyTime = leftkey->time;
-		curve.endKeyTime = rightkey->time;
+		curve.startKeyTime = (float)leftkey->time;
+		curve.endKeyTime = (float)rightkey->time;
 	}
 
 	int range = rightkey->time - leftkey->time;
@@ -480,10 +483,10 @@ void	SsAnimeDecoder::SsInterpolationValue( int time , const SsKeyframe* leftkey 
 			for ( int i = 0 ; i < 4 ; i++ )
 			{
 				v.colors[i].rate = clamp( SsInterpolate( SsInterpolationType::linear , now , leftv.colors[i].rate , rightv.colors[i].rate  , &curve ) , 0.0f , 1.0f );	
-				v.colors[i].rgba.a = clamp( SsInterpolate( SsInterpolationType::linear , now , leftv.colors[i].rgba.a , rightv.colors[i].rgba.a  , &curve ) , 0.0f , 255.0f );	
-				v.colors[i].rgba.r = clamp( SsInterpolate( SsInterpolationType::linear , now , leftv.colors[i].rgba.r , rightv.colors[i].rgba.r  , &curve ) , 0.0f , 255.0f );	
-				v.colors[i].rgba.g = clamp( SsInterpolate( SsInterpolationType::linear , now , leftv.colors[i].rgba.g , rightv.colors[i].rgba.g  , &curve ) , 0.0f , 255.0f );	
-				v.colors[i].rgba.b = clamp( SsInterpolate( SsInterpolationType::linear , now , leftv.colors[i].rgba.b , rightv.colors[i].rgba.b  , &curve ) , 0.0f , 255.0f );	
+				v.colors[i].rgba.a = (u32)(clamp( SsInterpolate( SsInterpolationType::linear , now , (float)leftv.colors[i].rgba.a , (float)rightv.colors[i].rgba.a  , &curve ) , 0.0f , 255.0f ));
+				v.colors[i].rgba.r = (u32)(clamp( SsInterpolate( SsInterpolationType::linear , now , (float)leftv.colors[i].rgba.r , (float)rightv.colors[i].rgba.r  , &curve ) , 0.0f , 255.0f ));
+				v.colors[i].rgba.g = (u32)(clamp( SsInterpolate( SsInterpolationType::linear , now , (float)leftv.colors[i].rgba.g , (float)rightv.colors[i].rgba.g  , &curve ) , 0.0f , 255.0f ));
+				v.colors[i].rgba.b = (u32)(clamp( SsInterpolate( SsInterpolationType::linear , now , (float)leftv.colors[i].rgba.b , (float)rightv.colors[i].rgba.b  , &curve ) , 0.0f , 255.0f ));
 			}
 		}
 		else
@@ -492,10 +495,10 @@ void	SsAnimeDecoder::SsInterpolationValue( int time , const SsKeyframe* leftkey 
 			for ( int i = 0 ; i < 4 ; i++ )
 			{
 				v.colors[i].rate = clamp( SsInterpolate( SsInterpolationType::linear , now , leftv.colors[i].rate , rightv.color.rate  , &curve ) , 0.0f , 1.0f );	
-				v.colors[i].rgba.a = clamp( SsInterpolate( SsInterpolationType::linear , now , leftv.colors[i].rgba.a , rightv.color.rgba.a  , &curve ) , 0.0f , 255.0f );	
-				v.colors[i].rgba.r = clamp( SsInterpolate( SsInterpolationType::linear , now , leftv.colors[i].rgba.r , rightv.color.rgba.r  , &curve ) , 0.0f , 255.0f );	
-				v.colors[i].rgba.g = clamp( SsInterpolate( SsInterpolationType::linear , now , leftv.colors[i].rgba.g , rightv.color.rgba.g  , &curve ) , 0.0f , 255.0f );	
-				v.colors[i].rgba.b = clamp( SsInterpolate( SsInterpolationType::linear , now , leftv.colors[i].rgba.b , rightv.color.rgba.b  , &curve ) , 0.0f , 255.0f );	
+				v.colors[i].rgba.a = (u32)(clamp( SsInterpolate( SsInterpolationType::linear , now , (float)leftv.colors[i].rgba.a , (float)rightv.color.rgba.a  , &curve ) , 0.0f , 255.0f ));
+				v.colors[i].rgba.r = (u32)(clamp( SsInterpolate( SsInterpolationType::linear , now , (float)leftv.colors[i].rgba.r , (float)rightv.color.rgba.r  , &curve ) , 0.0f , 255.0f ));
+				v.colors[i].rgba.g = (u32)(clamp( SsInterpolate( SsInterpolationType::linear , now , (float)leftv.colors[i].rgba.g , (float)rightv.color.rgba.g  , &curve ) , 0.0f , 255.0f ));
+				v.colors[i].rgba.b = (u32)(clamp( SsInterpolate( SsInterpolationType::linear , now , (float)leftv.colors[i].rgba.b , (float)rightv.color.rgba.b  , &curve ) , 0.0f , 255.0f ));
 			}
 		}
 	}
@@ -507,20 +510,20 @@ void	SsAnimeDecoder::SsInterpolationValue( int time , const SsKeyframe* leftkey 
 			for ( int i = 0 ; i < 4 ; i++ )
 			{
 				v.colors[i].rate = clamp( SsInterpolate( SsInterpolationType::linear , now , leftv.color.rate , rightv.colors[i].rate  , &curve ) , 0.0f , 1.0f );	
-				v.colors[i].rgba.a = clamp( SsInterpolate( SsInterpolationType::linear , now , leftv.color.rgba.a , rightv.colors[i].rgba.a  , &curve ) , 0.0f , 255.0f );		
-				v.colors[i].rgba.r = clamp( SsInterpolate( SsInterpolationType::linear , now , leftv.color.rgba.r , rightv.colors[i].rgba.r  , &curve ) , 0.0f , 255.0f );		
-				v.colors[i].rgba.g = clamp( SsInterpolate( SsInterpolationType::linear , now , leftv.color.rgba.g , rightv.colors[i].rgba.g  , &curve ) , 0.0f , 255.0f );		
-				v.colors[i].rgba.b = clamp( SsInterpolate( SsInterpolationType::linear , now , leftv.color.rgba.b , rightv.colors[i].rgba.b  , &curve ) , 0.0f , 255.0f );		
+				v.colors[i].rgba.a = (u32)(clamp( SsInterpolate( SsInterpolationType::linear , now , (float)leftv.color.rgba.a , (float)rightv.colors[i].rgba.a  , &curve ) , 0.0f , 255.0f ));
+				v.colors[i].rgba.r = (u32)(clamp( SsInterpolate( SsInterpolationType::linear , now , (float)leftv.color.rgba.r , (float)rightv.colors[i].rgba.r  , &curve ) , 0.0f , 255.0f ));
+				v.colors[i].rgba.g = (u32)(clamp( SsInterpolate( SsInterpolationType::linear , now , (float)leftv.color.rgba.g , (float)rightv.colors[i].rgba.g  , &curve ) , 0.0f , 255.0f ));
+				v.colors[i].rgba.b = (u32)(clamp( SsInterpolate( SsInterpolationType::linear , now , (float)leftv.color.rgba.b , (float)rightv.colors[i].rgba.b  , &curve ) , 0.0f , 255.0f ));
 			}
 		}
 		else
 		{
 			//両方とも単色
 			v.color.rate = clamp( SsInterpolate( SsInterpolationType::linear , now , leftv.color.rate , rightv.color.rate  , &curve ) , 0.0f , 1.0f );	
-			v.color.rgba.a = clamp( SsInterpolate( SsInterpolationType::linear , now , leftv.color.rgba.a , rightv.color.rgba.a  , &curve ) , 0.0f , 255.0f );	
-			v.color.rgba.r = clamp( SsInterpolate( SsInterpolationType::linear , now , leftv.color.rgba.r , rightv.color.rgba.r  , &curve ) , 0.0f , 255.0f );	
-			v.color.rgba.g = clamp( SsInterpolate( SsInterpolationType::linear , now , leftv.color.rgba.g , rightv.color.rgba.g  , &curve ) , 0.0f , 255.0f );	
-			v.color.rgba.b = clamp( SsInterpolate( SsInterpolationType::linear , now , leftv.color.rgba.b , rightv.color.rgba.b  , &curve) , 0.0f , 255.0f );	
+			v.color.rgba.a = (u32)(clamp( SsInterpolate( SsInterpolationType::linear , now , (float)leftv.color.rgba.a , (float)rightv.color.rgba.a  , &curve ) , 0.0f , 255.0f ));
+			v.color.rgba.r = (u32)(clamp( SsInterpolate( SsInterpolationType::linear , now , (float)leftv.color.rgba.r , (float)rightv.color.rgba.r  , &curve ) , 0.0f , 255.0f ));
+			v.color.rgba.g = (u32)(clamp( SsInterpolate( SsInterpolationType::linear , now , (float)leftv.color.rgba.g , (float)rightv.color.rgba.g  , &curve ) , 0.0f , 255.0f ));
+			v.color.rgba.b = (u32)(clamp( SsInterpolate( SsInterpolationType::linear , now , (float)leftv.color.rgba.b , (float)rightv.color.rgba.b  , &curve ) , 0.0f , 255.0f ));
 			v.target = SsColorBlendTarget::whole;
 		}
 	}
@@ -548,8 +551,8 @@ void	SsAnimeDecoder::SsInterpolationValue( int time , const SsKeyframe* leftkey 
 	if (leftkey->ipType == SsInterpolationType::bezier)
 	{
 		// ベジェのみキーの開始・終了時間が必要
-		curve.startKeyTime = leftkey->time;
-		curve.endKeyTime = rightkey->time;
+		curve.startKeyTime = (float)leftkey->time;
+		curve.endKeyTime = (float)rightkey->time;
 	}
 
 	int range = rightkey->time - leftkey->time;
@@ -628,8 +631,8 @@ void	SsAnimeDecoder::SsInterpolationValue(int time, const SsKeyframe* leftkey, c
 	if (leftkey->ipType == SsInterpolationType::bezier)
 	{
 		// ベジェのみキーの開始・終了時間が必要
-		curve.startKeyTime = leftkey->time;
-		curve.endKeyTime = rightkey->time;
+		curve.startKeyTime = (float)leftkey->time;
+		curve.endKeyTime = (float)rightkey->time;
 	}
 
 	float rate = SsInterpolate(leftkey->ipType, now, 0.0f, 1.0f, &curve);
@@ -639,14 +642,14 @@ void	SsAnimeDecoder::SsInterpolationValue(int time, const SsKeyframe* leftkey, c
 
 	std::vector<SsVector2> start = startValue.verticeChgList;
 	//start.resize(numPoints);
-	for (int i = start.size(); i < numPoints; i++)
+	for (int i = (int)(start.size()); i < numPoints; i++)
 	{
 		start.push_back(SsVector2(0, 0));
 	}
 
 	std::vector<SsVector2> end = endValue.verticeChgList;
 	//end.resize(numPoints);
-	for (int i = end.size(); i < numPoints; i++)
+	for (int i = (int)(end.size()); i < numPoints; i++)
 	{
 		end.push_back(SsVector2(0, 0));
 	}
@@ -687,12 +690,12 @@ void	SsAnimeDecoder::SsInterpolationValue( int time , const SsKeyframe* leftkey 
 		// ベジェのみキーの開始・終了時間が必要
 		SsCurve curve;
 		curve = leftkey->curve;
-		curve.startKeyTime = leftkey->time;
+		curve.startKeyTime = (float)leftkey->time;
 		curve.endKeyTime = (float)rightkey->time;
-		v = SsInterpolate( leftkey->ipType , now , v1 , v2 , &curve );
+		v = (mytype)(SsInterpolate( leftkey->ipType , now , v1 , v2 , &curve ));
 	}
 	else{
-		v = SsInterpolate( leftkey->ipType , now , v1 , v2 , &leftkey->curve );
+		v = (mytype)(SsInterpolate( leftkey->ipType , now , v1 , v2 , &leftkey->curve ));
 	}
 
 }
@@ -722,7 +725,7 @@ template<typename mytype> int	SsAnimeDecoder::SsGetKeyValue(SsPart* part, int ti
 			{
 				SsAttributeList attList;
 				attList = setupAnime->attributes;
-				foreach(SsAttributeList, attList, e)
+				SPRITESTUDIO6DSK_foreach(SsAttributeList, attList, e)
 				{
 					SsAttribute* setupattr = (*e);
 					if (setupattr->tag == attr->tag)
@@ -887,7 +890,7 @@ void	SsAnimeDecoder::updateState( int nowTime , SsPart* part , SsPartAnime* anim
 			}
 			attList = anime->attributes;
 		}
-		foreach( SsAttributeList , attList , e )
+		SPRITESTUDIO6DSK_foreach( SsAttributeList , attList , e )
 		{
 			SsAttribute* attr = (*e);
 			switch( attr->tag )
@@ -1053,7 +1056,7 @@ void	SsAnimeDecoder::updateState( int nowTime , SsPart* part , SsPartAnime* anim
 							if ( !state->effectValue.attrInitialized )
 							{
 								state->effectValue.attrInitialized  = true;
-								state->effectTimeTotal = state->effectValue.startTime;
+								state->effectTimeTotal = (float)(state->effectValue.startTime);
 								state->effectTime = t;//state->effectValue.startTime;
 							}
 						}
@@ -1162,7 +1165,7 @@ void	SsAnimeDecoder::updateMatrix(SsPart* part , SsPartAnime* anime , SsPartStat
 		}
 
 		TranslationMatrixM( pmat , state->position.x, state->position.y, state->position.z );//
-		RotationXYZMatrixM( pmat , DegreeToRadian(state->rotation.x) , DegreeToRadian(state->rotation.y) , DegreeToRadian( state->rotation.z) );
+		RotationXYZMatrixM( pmat , (float)(DegreeToRadian(state->rotation.x)) , (float)(DegreeToRadian(state->rotation.y)) , (float)(DegreeToRadian( state->rotation.z)) );
 		float sx = state->scale.x;
 		float sy = state->scale.y;
 		if (matcnt > 0)
@@ -1229,7 +1232,7 @@ void	SsAnimeDecoder::updateVertices(SsPart* part , SsPartAnime* anime , SsPartSt
 	SsPoint2 * vtxOfs = state->vertexValue.offsets;
 
 	//きれいな頂点変形に対応
-#if USE_TRIANGLE_FIN
+#if SPRITESTUDIO6SDK_USE_TRIANGLE_FIN
 
 	if ( state->is_parts_color || state->is_vertex_transform )
 	{
@@ -1337,7 +1340,7 @@ void	SsAnimeDecoder::updateInstance( int nowTime , SsPart* part , SsPartAnime* p
     int	selfTopKeyframe = instanceValue.curKeyframe;
 
 
-    int reftime = ( time - selfTopKeyframe) * instanceValue.speed;
+    int reftime = (int)(( time - selfTopKeyframe) * instanceValue.speed);
     //int	reftime = (time*instanceValue.speed) - selfTopKeyframe; //開始から現在の経過時間
 	if ( reftime < 0 ) return ; //そもそも生存時間に存在していない
 	if ( selfTopKeyframe > time ) return ;
@@ -1393,7 +1396,7 @@ void	SsAnimeDecoder::updateInstance( int nowTime , SsPart* part , SsPartAnime* p
     }
 
 	state->refAnime->setInstancePartsHide(state->hide);
-	state->refAnime->setPlayFrame(_time);
+	state->refAnime->setPlayFrame((float)_time);
 
 	//Ver6 ローカルスケール対応
 	//ローカルスケールを適用するために一時的に継承マトリクスを入れ替える
@@ -1500,7 +1503,7 @@ void	SsAnimeDecoder::update(float frameDelta)
 	this->frameDelta = frameDelta;
 
 	int cnt = 0;
-	foreach( std::vector<SsPartAndAnime> , partAnime , e )
+	SPRITESTUDIO6DSK_foreach( std::vector<SsPartAndAnime> , partAnime , e )
 	{
 		SsPart* part = e->first;
 		SsPartAnime* anime = e->second;
@@ -1562,7 +1565,7 @@ void	SsAnimeDecoder::updateEffect( float frameDelta , int nowTime , SsPart* part
 	}else{
 		if (state && state->refEffect)
 		{
-			float _time = nowTime - state->effectTime;
+			float _time = (float)(nowTime - state->effectTime);
 			if ( _time < 0 )
 			{
 				return ;
@@ -1606,7 +1609,7 @@ void	SsAnimeDecoder::draw()
 
 	int mask_index = 0;
 
-	foreach( std::list<SsPartState*> , sortList , e )
+	SPRITESTUDIO6DSK_foreach( std::list<SsPartState*> , sortList , e )
 	{
 		SsPartState* state = (*e);
 
@@ -1675,4 +1678,6 @@ void	SsAnimeDecoder::draw()
 
 	SsCurrentRenderer::getRender()->enableMask(false);
 }
+
+}	// namespace spritestudio6
 

--- a/Common/Animator/ssplayer_animedecode.h
+++ b/Common/Animator/ssplayer_animedecode.h
@@ -10,18 +10,18 @@
 #include "ssplayer_PartState.h"
 #include "ssplayer_macro.h"
 
+//きれいな頂点変形に対応する場合は1にする。
+//４ポリゴンで変形します。
+//0の場合はZ型の２ポリゴンで変形します。
+#define SPRITESTUDIO6SDK_USE_TRIANGLE_FIN (1)
 
-
+namespace spritestudio6
+{
 
 class SsAnimeDecoder;
 class SsCelMapLinker;
 class SsMeshAnimator;
 
-
-//きれいな頂点変形に対応する場合は1にする。
-//４ポリゴンで変形します。
-//0の場合はZ型の２ポリゴンで変形します。
-#define USE_TRIANGLE_FIN (1)
 
 //パーツとアニメを関連付ける
 typedef std::pair<SsPart*,SsPartAnime*>	SsPartAndAnime;
@@ -124,7 +124,7 @@ public:
 	int		getAnimeTotalFrame() { return curAnimeTotalFrame; }
 	int		getAnimeFPS() {	return curAnimeFPS; }		
 
-	int		getSequenceItemCount() { return curSequence->list.size(); }
+	int		getSequenceItemCount() { return (int)(curSequence->list.size()); }
 	SsSequenceItem*	getSequenceItem( int iIndex ) { return curSequence->list[iIndex]; }
 
 	size_t	getStateNum() { return stateNum; }
@@ -163,5 +163,6 @@ public:
 };
 
 
+}	// namespace spritestudio6
 
 #endif

--- a/Common/Animator/ssplayer_cellmap.cpp
+++ b/Common/Animator/ssplayer_cellmap.cpp
@@ -10,6 +10,8 @@
 
 #include "../Helper/DebugPrint.h"
 
+namespace spritestudio6
+{
 
 bool SsCellMapList::preloadTexture(SsProject* proj)
 {
@@ -247,3 +249,6 @@ void calcUvs( SsCellValue* cellv )
 		cellv->uvs[2].y = cellv->uvs[3].y = bottom;
 	}
 }
+
+}	// namespace spritestudio6
+

--- a/Common/Animator/ssplayer_cellmap.h
+++ b/Common/Animator/ssplayer_cellmap.h
@@ -1,7 +1,8 @@
 ﻿#ifndef __SSPLAYER_CELLMAP__
 #define __SSPLAYER_CELLMAP__
 
-
+namespace spritestudio6
+{
 
 class SsAnimeDecoder;
 class SsCelMapLinker;
@@ -115,5 +116,8 @@ void getCellValue( SsCellMapList* cellList, int cellMapid , SsString& cellName ,
 void getCellValue( SsCellMapList* cellList, SsString& cellMapName , SsString& cellName , SsCellValue& v );
 
 void calcUvs( SsCellValue* cellv );
+
+
+}	// namespace spritestudio6
 
 #endif

--- a/Common/Animator/ssplayer_effect.cpp
+++ b/Common/Animator/ssplayer_effect.cpp
@@ -11,6 +11,9 @@
 #include "ssplayer_effectfunction.h"
 
 
+namespace spritestudio6
+{
+
 
 class SsEffectRenderParticle;
 
@@ -53,9 +56,8 @@ static  int seed_table[] =
 //--------
 
 
-
-#define ONEFRAME ( 1.0f / 60.0f )
-
+// #define ONEFRAME ( 1.0f / 60.0f )
+constexpr auto ONEFRAME = ( 1.0f / 60.0f );
 
 
 //------------------------------------------------------------------------------
@@ -64,7 +66,7 @@ static  int seed_table[] =
 SsEffectDrawBatch*	SsEffectRenderer::findBatchListSub(SsEffectNode* n)
 {
 	SsEffectDrawBatch* bl = 0;
-	foreach( std::list<SsEffectDrawBatch*> , drawBatchList , e )
+	SPRITESTUDIO6DSK_foreach( std::list<SsEffectDrawBatch*> , drawBatchList , e )
 	{
 		if ( (*e)->targetNode == n )
 		{
@@ -108,7 +110,7 @@ SsEffectRenderAtom* SsEffectRenderer::CreateAtom( unsigned int seed , SsEffectRe
 
 	if ( type == SsEffectNodeType::particle )
 	{
-#if PFMEM_TEST
+#if SPRITESTUDIO6SDK_PFMEM_TEST
 		if ( SSEFFECTRENDER_PARTICLE_MAX <= pa_pool_count )
 		{
 			 return 0;
@@ -136,7 +138,7 @@ SsEffectRenderAtom* SsEffectRenderer::CreateAtom( unsigned int seed , SsEffectRe
 	if ( type == SsEffectNodeType::emmiter )
 	{
 
-#if PFMEM_TEST
+#if SPRITESTUDIO6SDK_PFMEM_TEST
 		if ( SSEFFECTRENDER_EMMITER_MAX <= em_pool_count )
 		{
 			return 0;
@@ -290,7 +292,7 @@ bool	SsEffectRenderEmitter::genarate( SsEffectRenderer* render )
 	if ( create_count <= 0 ) create_count = 1;
 
 
-	int pc = particleCount;
+	int pc = (int)particleCount;
 
 	while(1)
 	{
@@ -553,7 +555,7 @@ void	SsEffectRenderParticle::draw(SsEffectRenderer* render)
 
 	TranslationMatrixM( matrix , _position.x, _position.y, 0.0f );
 
-	RotationXYZMatrixM( matrix , 0 , 0 , DegreeToRadian(_rotation)+direction );
+	RotationXYZMatrixM( matrix , 0.0f , 0.0f , (float)(DegreeToRadian(_rotation)+direction) );
 
     ScaleMatrixM(  matrix , _size.x, _size.y, 1.0f );
 
@@ -574,7 +576,7 @@ void	SsEffectRenderParticle::draw(SsEffectRenderer* render)
 
 		SsCurrentRenderer::getRender()->renderSpriteSimple(
 			matrix,
-			dispscale.x , dispscale.y ,  pivot,
+			(int)dispscale.x , (int)dispscale.y ,  pivot,
 					dispCell->uvs[0],
 					dispCell->uvs[3], fcolor );
 	}
@@ -677,7 +679,7 @@ void	SsEffectRenderer::draw()
 
 	int cnt = 0;
 
-	foreach( std::list<SsEffectDrawBatch*> , drawBatchList , e )
+	SPRITESTUDIO6DSK_foreach( std::list<SsEffectDrawBatch*> , drawBatchList , e )
 	{
 		//セットアップ
 		if ( (*e)->dispCell )
@@ -694,7 +696,7 @@ void	SsEffectRenderer::draw()
 			SsCurrentRenderer::getRender()->SetTexture( (*e)->dispCell );
 		}
 
-		foreach( std::list<SsEffectRenderAtom*> , (*e)->drawlist , e2 )
+		SPRITESTUDIO6DSK_foreach( std::list<SsEffectRenderAtom*> , (*e)->drawlist , e2 )
 		{
 			if ( (*e2) )
 			{
@@ -738,7 +740,7 @@ void	SsEffectRenderer::clearUpdateList()
 	size_t s2 = updatelist.size();
 
 
-#if PFMEM_TEST
+#if SPRITESTUDIO6SDK_PFMEM_TEST
 	em_pool_count = 0;
 	pa_pool_count = 0;
 	dpr_pool_count = 0;
@@ -753,7 +755,7 @@ void	SsEffectRenderer::clearUpdateList()
 	updatelist.clear();
 	createlist.clear();
 
-	foreach( std::list<SsEffectDrawBatch*> , drawBatchList , e )
+	SPRITESTUDIO6DSK_foreach( std::list<SsEffectDrawBatch*> , drawBatchList , e )
 	{
 		(*e)->drawlist.clear();
 	}
@@ -837,5 +839,6 @@ bool	SsEffectRenderer::getPlayStatus(void)
 
 
 
+}	// namespace spritestudio6
 
 

--- a/Common/Animator/ssplayer_effect.h
+++ b/Common/Animator/ssplayer_effect.h
@@ -6,6 +6,12 @@
 #include "ssplayer_cellmap.h"
 
 
+// PFMEM_TEST
+#define SPRITESTUDIO6SDK_PFMEM_TEST ( 1 )
+
+namespace spritestudio6
+{
+
 class SsEffectModel;
 class SsRenderEffectBase;
 class SsEffectNode;
@@ -16,10 +22,6 @@ class SsCell;
 
 class SsEffectBehavior;
 class SsEffectRenderer;
-
-
-#define PFMEM_TEST ( 1 )
-
 
 
 namespace SsRenderType
@@ -140,7 +142,7 @@ public:
 	{
 #ifdef _WIN32
         
-		rotation = std::fmod( z , 360 ) ;
+		rotation = (float)( std::fmod( z , 360 ) ) ;
 #else
         rotation = fmod( z , 360 ) ;
         
@@ -391,12 +393,12 @@ public:
 // アニメーション初期化時にバッファ確保の時間が長くなります。
 // 再生するアニメーションにエフェクトパーツがない場合は初期化が行われなわれないので負荷は発生しません。
 //SpriteStudio本体の設定
-#define SSEFFECTRENDER_EMMITER_MAX (1024)
-#define SSEFFECTRENDER_PARTICLE_MAX (4096)
-//#define SSEFFECTRENDER_EMMITER_MAX (256)
-//#define SSEFFECTRENDER_PARTICLE_MAX (2048)
+constexpr auto SSEFFECTRENDER_EMMITER_MAX = 1024;
+constexpr auto SSEFFECTRENDER_PARTICLE_MAX = 4096;
+// constexpr auto SSEFFECTRENDER_EMMITER_MAX = 256;
+// constexpr auto SSEFFECTRENDER_PARTICLE_MAX = 2048;
 //-------------------------------------------------------------
-#define SSEFFECTRENDER_BACTH_MAX (256)
+constexpr auto SSEFFECTRENDER_BACTH_MAX = 256;
 
 
 
@@ -420,7 +422,7 @@ private:
 	SsCellMapList*	curCellMapManager;/// セルマップのリスト（アニメデコーダーからもらう
 
 
-#if PFMEM_TEST
+#if SPRITESTUDIO6SDK_PFMEM_TEST
 	SsEffectRenderEmitter    em_pool[SSEFFECTRENDER_EMMITER_MAX+1];
 	SsEffectRenderParticle   pa_pool[SSEFFECTRENDER_PARTICLE_MAX+1];
 
@@ -451,7 +453,7 @@ public:
 
 public:
 	SsEffectRenderer() : effectData(0) , parentState(0) ,mySeed(0) , render_root(0),parentAnimeStartFrame(0) , m_isLoop(false)
-#if PFMEM_TEST
+#if SPRITESTUDIO6SDK_PFMEM_TEST
 	,em_pool_count(0)
 	,pa_pool_count(0)
 	,dpr_pool_count(0)
@@ -517,6 +519,6 @@ public:
 };
 
 
-
+}	// namespace spritestudio6
 
 #endif

--- a/Common/Animator/ssplayer_effect2.cpp
+++ b/Common/Animator/ssplayer_effect2.cpp
@@ -11,15 +11,18 @@
 #include "ssplayer_render.h"
 #include "ssplayer_effectfunction.h"
 
+// MEMO: cpp側でのファイルスコープなので大丈夫かとは思うが、念のためSPRITESTUDIO6SDK_を接頭しておく
+//       ※ちなみにどちらも使用していない。
+#define SPRITESTUDIO6SDK_DEBUG_DISP (0)
+#define SPRITESTUDIO6SDK_BUILD_ERROR_0418 (0)
 
-#define DEBUG_DISP (0)
-#define BUILD_ERROR_0418 (0)
-
+namespace spritestudio6
+{
 
 
 static u8 blendNumber( u8 a , u8 b , float rate )
 {
-	return ( a + ( b - a ) * rate );
+	return (u8)((int)( a + ( b - a ) * rate ));
 }
 
 static float blendFloat( float a,float b , float rate )
@@ -77,7 +80,7 @@ void	SsEffectEmitter::updateParticle(float time, particleDrawData* p, bool recal
 		if ( _speed <= 0 )_speed = 0.1f;
 		//平均角速度を求める
 		float l = _life * _speed * 0.2f; //円の半径
-		float c = 3.14 * l;
+		float c = 3.14f * l;
 
 		//最円周 / 加速度(pixel)
 		addr = ( accel / c ) * _t;
@@ -111,8 +114,8 @@ void	SsEffectEmitter::updateParticle(float time, particleDrawData* p, bool recal
 	//重力加速度の計算
 	if ( particle.useGravity )
 	{
-		x += (0.5 * particle.gravity.x * (_t2));
-		y += (0.5 * particle.gravity.y * (_t2));
+		x += (0.5f * particle.gravity.x * (_t2));
+		y += (0.5f * particle.gravity.y * (_t2));
 	}
 
 	//初期位置オフセット
@@ -174,19 +177,19 @@ void	SsEffectEmitter::updateParticle(float time, particleDrawData* p, bool recal
 
 	if ( particle.useColor)
 	{
-		p->color.a = particle.initColor.a + (rand.genrand_float32() * particle.initColor2.a );
-		p->color.r = particle.initColor.r + (rand.genrand_float32() * particle.initColor2.r );
-		p->color.g = particle.initColor.g + (rand.genrand_float32() * particle.initColor2.g );
-		p->color.b = particle.initColor.b + (rand.genrand_float32() * particle.initColor2.b );
+		p->color.a = particle.initColor.a + (u8)(rand.genrand_float32() * particle.initColor2.a );
+		p->color.r = particle.initColor.r + (u8)(rand.genrand_float32() * particle.initColor2.r );
+		p->color.g = particle.initColor.g + (u8)(rand.genrand_float32() * particle.initColor2.g );
+		p->color.b = particle.initColor.b + (u8)(rand.genrand_float32() * particle.initColor2.b );
 	}
 
 	if ( particle.useTransColor )
 	{
 		SsU8Color ecolor;
-		ecolor.a = particle.transColor.a + (rand.genrand_float32() * particle.transColor2.a );
-		ecolor.r = particle.transColor.r + (rand.genrand_float32() * particle.transColor2.r );
-		ecolor.g = particle.transColor.g + (rand.genrand_float32() * particle.transColor2.g );
-		ecolor.b = particle.transColor.b + (rand.genrand_float32() * particle.transColor2.b );
+		ecolor.a = particle.transColor.a + (u8)(rand.genrand_float32() * particle.transColor2.a );
+		ecolor.r = particle.transColor.r + (u8)(rand.genrand_float32() * particle.transColor2.r );
+		ecolor.g = particle.transColor.g + (u8)(rand.genrand_float32() * particle.transColor2.g );
+		ecolor.b = particle.transColor.b + (u8)(rand.genrand_float32() * particle.transColor2.b );
 
 		p->color.a = blendNumber( p->color.a , ecolor.a , _lifeper );
 		p->color.r = blendNumber( p->color.r , ecolor.r , _lifeper );
@@ -205,7 +208,8 @@ void	SsEffectEmitter::updateParticle(float time, particleDrawData* p, bool recal
 		if ( ( per < start ) && ( start > 0.0f ) ) //Ver6.2　0除算発生する可能性対策
 		{
 			float alpha = (start - per) / start;
-			p->color.a*= 1.0f - alpha;
+//			p->color.a*= 1.0f - alpha;
+			p->color.a = (u8)((float)p->color.a * (1.0f - alpha));
 		}else{
 
 			if ( per > end )
@@ -218,7 +222,8 @@ void	SsEffectEmitter::updateParticle(float time, particleDrawData* p, bool recal
 					float alpha = (per-end) / (100.0f-end);
                     if ( alpha >=1.0f ) alpha = 1.0f;
 
-					p->color.a*= 1.0f - alpha;
+//					p->color.a*= 1.0f - alpha;
+					p->color.a = (u8)((float)p->color.a * (1.0f - alpha));
 				}
 			}
 		}
@@ -299,7 +304,7 @@ void	SsEffectEmitter::updateParticle(float time, particleDrawData* p, bool recal
 			p->y += nv.y;
 
 
-			float blend = OutQuad(_gt, et, 0.9f, 0.0f);
+			float blend = (float)(OutQuad(_gt, et, 0.9f, 0.0f));
 			blend = blend; // *gp;
 			blend += (_t / _life *0.1f);
 
@@ -345,7 +350,7 @@ void	SsEffectEmitter::updateParticle(float time, particleDrawData* p, bool recal
 			updateParticle( time + 1.0f , &dp , true );
 			p->direc =  SsVector2::get_angle_360(
 								SsVector2( 1 , 0 ) ,
-								SsVector2(p->x - dp.x, p->y - dp.y) ) + DegreeToRadian(90) + DegreeToRadian(particle.direcRotAdd);
+								SsVector2(p->x - dp.x, p->y - dp.y) ) + (float)(DegreeToRadian(90) + DegreeToRadian(particle.direcRotAdd));
 		}
 	}
 
@@ -391,7 +396,7 @@ void	SsEffectEmitter::precalculate2()
 
 
 	int shot = 0;
-	int offset = particle.delay;
+	int offset = (int)(particle.delay);
 	for ( int i = 0 ; i < emitter.emitmax ; i++ )
 	{
 		if ( shot >= emitter.emitnum )
@@ -408,7 +413,7 @@ void	SsEffectEmitter::precalculate2()
 	{
 		emitPattern e;
 		e.uid = i;
-		e.life = emitter.particleLife + emitter.particleLife2 * rand.genrand_float32();
+		e.life = emitter.particleLife + (int)(emitter.particleLife2 * rand.genrand_float32());
 		e.cycle = cycle;
 
 		if ( e.life > cycle )
@@ -449,8 +454,8 @@ void	SsEffectEmitter::precalculate2()
 
 void SsEffectEmitter::updateEmitter( double _time , int slide ) 
 {
-	int onum = _offsetPattern.size();
-	int pnum = _emitpattern.size();
+	int onum = (int)(_offsetPattern.size());
+	int pnum = (int)(_emitpattern.size());
 	slide = slide * SEED_MAGIC;
 
 
@@ -561,7 +566,7 @@ void	SsEffectRenderV2::drawSprite(
 
 	TranslationMatrixM( matrix , _position.x * layoutScale.x , _position.y * layoutScale.y , 0.0f );
 
-	RotationXYZMatrixM( matrix , 0 , 0 , DegreeToRadian(_rotation)+direction );
+	RotationXYZMatrixM( matrix , 0 , 0 , (float)(DegreeToRadian(_rotation))+direction );
 
     ScaleMatrixM(  matrix , _size.x, _size.y, 1.0f );
 
@@ -583,7 +588,7 @@ void	SsEffectRenderV2::drawSprite(
 
 		SsCurrentRenderer::getRender()->renderSpriteSimple(
 			matrix,
-			dispscale.x , dispscale.y ,  pivot,
+			(int)dispscale.x , (int)dispscale.y ,  pivot,
 					dispCell->uvs[0],
 					dispCell->uvs[3], fcolor );
 	}	
@@ -611,7 +616,7 @@ void SsEffectRenderV2::particleDraw(SsEffectEmitter* e , double time , SsEffectE
 
         if ( !drawe->born )continue;
 
-		float targettime = (t + 0.0f);
+		float targettime = ((float)t + 0.0f);
 		particleDrawData lp;
 		particleDrawData pp;
 		pp.x = 0; pp.y = 0;
@@ -642,7 +647,7 @@ void SsEffectRenderV2::particleDraw(SsEffectEmitter* e , double time , SsEffectE
 				if ( ptime > lp.lifetime ) ptime = lp.lifetime;
 
 				//逆算はデバッグしずらいかもしれない
-				parent->updateParticle( lp.stime + pp.stime , &pp);
+				parent->updateParticle( (float)lp.stime + pp.stime , &pp);
 				e->position.x = pp.x;
 				e->position.y = pp.y;
 
@@ -711,7 +716,7 @@ void	SsEffectRenderV2::initEmitter( SsEffectEmitter* e , SsEffectNode* node)
 		}
 	}
 
-	e->emitter.life+= e->particle.delay;//ディレイ分加算
+	e->emitter.life += (int)e->particle.delay;//ディレイ分加算
 }
 
 
@@ -751,8 +756,8 @@ void	SsEffectRenderV2::update()
 		{
 			if ( nowFrame > getEffectTimeLength() )
 			{
-				targetFrame = (int)((int)nowFrame % getEffectTimeLength());
-				int l = ( nowFrame / getEffectTimeLength() );
+				targetFrame = (float)((int)nowFrame % getEffectTimeLength());
+				int l = (int)( nowFrame / (float)(getEffectTimeLength()) );
 				setSeedOffset( l );
 			}
 		}
@@ -903,7 +908,7 @@ void    SsEffectRenderV2::reload()
 	{
 		if (emmiterList[i] != 0 )
 		{
-			emmiterList[i]->uid = i;
+			emmiterList[i]->uid = (int)i;
 			//emmiterList[i]->precalculate();
 			emmiterList[i]->precalculate2(); //ループ対応形式
 
@@ -921,7 +926,7 @@ void    SsEffectRenderV2::reload()
 
                 emmiterList[i]->_parent = emmiterList[pi];
 
-				emmiterList[i]->globaltime = emmiterList[i]->getTimeLength() + this->emmiterList[pi]->getTimeLength();
+				emmiterList[i]->globaltime = (size_t)(emmiterList[i]->getTimeLength()) + (size_t)(this->emmiterList[pi]->getTimeLength());
 
 				updateList.push_back(emmiterList[i]);
 			}
@@ -955,3 +960,6 @@ int	SsEffectRenderV2::getCurrentFPS(){
 	}
 	return 30;
 }
+
+}	// namespace spritestudio6
+

--- a/Common/Animator/ssplayer_effect2.h
+++ b/Common/Animator/ssplayer_effect2.h
@@ -9,23 +9,25 @@
 
 //#include "ISSEffectRender.h"
 
+// MEMO: コンパイル設定
+#define SPRITESTUDIO6SDK_LOOP_TYPE1 (0)
+#define SPRITESTUDIO6SDK_LOOP_TYPE2 (0)
+#define SPRITESTUDIO6SDK_LOOP_TYPE3 (1)
 
+namespace spritestudio6
+{
 
 class SsEffectModel;
 class SsRenderEffectBase;
 class SsEffectNode;
-class SsPartState;
+struct SsPartState;
 class SsEffectRenderAtom;
 class SsCell;
 
 
-#define SEED_MAGIC (7573)
-#define LIFE_EXTEND_SCALE (8)
-#define LIFE_EXTEND_MIN	  (64)
-
-#define LOOP_TYPE1 (0)
-#define LOOP_TYPE2 (0)
-#define LOOP_TYPE3 (1)
+constexpr auto SEED_MAGIC = 7573;
+constexpr auto LIFE_EXTEND_SCALE = 8;
+constexpr auto LIFE_EXTEND_MIN = 64;
 
 
 struct TimeAndValue
@@ -316,9 +318,9 @@ public:
 
 //	const particleLifeSt*	getParticleDataFromID(int id) { return &particleList[id]; }
 
-#if  LOOP_TYPE3
+#if  SPRITESTUDIO6SDK_LOOP_TYPE3
 
-	int	getParticleIDMax() { return _offsetPattern.size(); }
+	int	getParticleIDMax() { return (int)(_offsetPattern.size()); }
 
 	const 	particleExistSt*	getParticleDataFromID(int id);
 	void	updateEmitter( double time  , int slide );
@@ -467,5 +469,6 @@ public:
 
 };
 
+}	// namespace spritestudio6
 
 #endif

--- a/Common/Animator/ssplayer_effectfunction.cpp
+++ b/Common/Animator/ssplayer_effectfunction.cpp
@@ -10,6 +10,8 @@
 #include "ssplayer_effectfunction.h"
 
 
+namespace spritestudio6
+{
 
 
 //二つの値の範囲から値をランダムで得る
@@ -66,7 +68,7 @@ static float VarianceCalcFin( SsEffectRenderEmitter* e ,  float base , float var
 
 static u8 blendNumber( u8 a , u8 b , float rate )
 {
-	return ( a + ( b - a ) * rate );
+	return ( ( a + (u8)((float)( b - a ) * rate )) );
 }
 
 
@@ -108,9 +110,9 @@ public:
 		ParticleElementBasic* source = static_cast<ParticleElementBasic*>(ele);
 
 		e->maxParticle = source->maximumParticle;
-		e->interval = source->interval;
-		e->_lifetime = source->lifetime;
-		e->_life = source->lifetime;
+		e->interval = (float)source->interval;
+		e->_lifetime = (float)source->lifetime;
+		e->_life = (float)source->lifetime;
 		e->burst = source->attimeCreate;
 
 		e->undead = false;
@@ -141,11 +143,11 @@ public:
 
 		p->_backposition = p->_position;
 
-		p->_lifetime   = VarianceCalc( e , source->lifespan.getMinValue() , source->lifespan.getMaxValue() );
-		p->_life = source->lifetime;
+		p->_lifetime = VarianceCalc( e , (float)(source->lifespan.getMinValue()) , (float)(source->lifespan.getMaxValue()) );
+		p->_life = (float)source->lifetime;
 		float temp_angle = VarianceCalcFin( e ,  source->angle+eAngle , source->angleVariance/2.0f);
 
-		float angle_rad = DegreeToRadian( (temp_angle+90.0f) );
+		float angle_rad = (float)(DegreeToRadian( (temp_angle+90.0f) ));
 		float lspeed = VarianceCalc(  e , source->speed.getMinValue() , source->speed.getMaxValue() );
 
 		p->speed = lspeed;
@@ -191,8 +193,8 @@ public:
 		e->particle.speed = source->speed.getMinValue();
 		e->particle.speed2 = source->speed.getMaxValue() - source->speed.getMinValue();
 
-		e->particle.angle = DegreeToRadian( (source->angle+90.0f) );
-		e->particle.angleVariance = DegreeToRadian( source->angleVariance );
+		e->particle.angle = (float)(DegreeToRadian( (source->angle+90.0f) ));
+		e->particle.angleVariance = (float)(DegreeToRadian( source->angleVariance ));
 
 		e->particle.useTanAccel = false;
 
@@ -293,7 +295,7 @@ public:
 	virtual void	initalizeEffect ( SsEffectElementBase* ele , SsEffectEmitter* e)
 	{
 		ParticleElementDelay* source = static_cast<ParticleElementDelay*>(ele);
-		e->particle.delay = source->DelayTime;
+		e->particle.delay = (float)source->DelayTime;
 
 	}
 	
@@ -628,7 +630,8 @@ public:
 		if ( per < start )
 		{
 			float alpha = (start - per) / start;
-			particle->_color.a*= 1.0f - alpha;
+//			particle->_color.a*= 1.0f - alpha;
+			particle->_color.a = (u8)((float)particle->_color.a * (1.0f - alpha));
 			return;
 		}
 
@@ -641,7 +644,8 @@ public:
 				return;
 			}
 			float alpha = (per-end) / (100.0f-end);
-			particle->_color.a*= 1.0f - alpha;
+//			particle->_color.a*= 1.0f - alpha;
+			particle->_color.a = (u8)((float)particle->_color.a * (1.0f - alpha));
 			return;
 		}
 
@@ -879,7 +883,7 @@ static EffectFuncBase* callTable[] =
 ///----------------------------------------------------------------------------------------------------
 void	SsEffectFunctionExecuter::initalize( SsEffectBehavior* beh ,  SsEffectRenderEmitter* emmiter)
 {
-	foreach( std::vector<SsEffectElementBase* > , beh->plist , e )
+	SPRITESTUDIO6DSK_foreach( std::vector<SsEffectElementBase* > , beh->plist , e )
 	{
 		EffectFuncBase* cf = callTable[(*e)->myType];
 		cf->initalizeEmmiter( (*e) , emmiter );
@@ -888,7 +892,7 @@ void	SsEffectFunctionExecuter::initalize( SsEffectBehavior* beh ,  SsEffectRende
 
 void	SsEffectFunctionExecuter::updateEmmiter( SsEffectBehavior* beh , SsEffectRenderEmitter* emmiter)
 {
-	foreach( std::vector<SsEffectElementBase* > , beh->plist , e )
+	SPRITESTUDIO6DSK_foreach( std::vector<SsEffectElementBase* > , beh->plist , e )
 	{
 		EffectFuncBase* cf = callTable[(*e)->myType];
 		cf->updateEmmiter( (*e) , emmiter );
@@ -897,7 +901,7 @@ void	SsEffectFunctionExecuter::updateEmmiter( SsEffectBehavior* beh , SsEffectRe
 
 void	SsEffectFunctionExecuter::initializeParticle( SsEffectBehavior* beh ,  SsEffectRenderEmitter* emmiter , SsEffectRenderParticle* particle )
 {
-	foreach( std::vector<SsEffectElementBase* > , beh->plist , e )
+	SPRITESTUDIO6DSK_foreach( std::vector<SsEffectElementBase* > , beh->plist , e )
 	{
 		EffectFuncBase* cf = callTable[(*e)->myType];
 		cf->initializeParticle( (*e) , emmiter , particle );
@@ -906,7 +910,7 @@ void	SsEffectFunctionExecuter::initializeParticle( SsEffectBehavior* beh ,  SsEf
 
 void	SsEffectFunctionExecuter::updateParticle(  SsEffectBehavior* beh , SsEffectRenderEmitter* emmiter , SsEffectRenderParticle* particle )
 {
-	foreach( std::vector<SsEffectElementBase* > , beh->plist , e )
+	SPRITESTUDIO6DSK_foreach( std::vector<SsEffectElementBase* > , beh->plist , e )
 	{
 		EffectFuncBase* cf = callTable[(*e)->myType];
 		cf->updateParticle( (*e) , emmiter , particle );
@@ -916,7 +920,7 @@ void	SsEffectFunctionExecuter::updateParticle(  SsEffectBehavior* beh , SsEffect
 
 void	SsEffectFunctionExecuter::initializeEffect( SsEffectBehavior* beh ,  SsEffectEmitter* emmiter)
 {
-	foreach( std::vector<SsEffectElementBase* > , beh->plist , e )
+	SPRITESTUDIO6DSK_foreach( std::vector<SsEffectElementBase* > , beh->plist , e )
 	{
 		EffectFuncBase* cf = callTable[(*e)->myType];
 		cf->initalizeEffect( (*e) , emmiter );
@@ -928,14 +932,4 @@ void	SsEffectFunctionExecuter::initializeEffect( SsEffectBehavior* beh ,  SsEffe
 
 
 
-
-
-
-
-
-
-
-
-
-
-
+}	// namespace spritestudio6

--- a/Common/Animator/ssplayer_effectfunction.h
+++ b/Common/Animator/ssplayer_effectfunction.h
@@ -4,6 +4,9 @@
 #include "ssplayer_effect.h"
 #include "ssplayer_effect2.h"
 
+namespace spritestudio6
+{
+
 class	SsEffectFunctionExecuter
 {
 public:
@@ -23,8 +26,6 @@ public:
 };
 
 
-
-
-
+}	// namespace spritestudio6
 
 #endif

--- a/Common/Animator/ssplayer_macro.h
+++ b/Common/Animator/ssplayer_macro.h
@@ -2,12 +2,23 @@
 #define __SSPLAYER_MACRO__
 
 
+namespace spritestudio6
+{
 
-#define __PI__	(3.14159265358979323846f)
-#define RadianToDegree(Radian) ((double)Radian * (180.0f / __PI__))
-#define DegreeToRadian(Degree) ((double)Degree * (__PI__ / 180.0f))
+constexpr auto __PI__ = (3.14159265358979323846f);
+// #define RadianToDegree(Radian) ((double)Radian * (180.0f / __PI__))
+template<typename T> inline double RadianToDegree(T Radian)
+{
+	return((double)Radian * (180.0f / __PI__));
+}
+// #define DegreeToRadian(Degree) ((double)Degree * (__PI__ / 180.0f))
+template<typename T> inline double DegreeToRadian(T Degree)
+{
+	return((double)Degree * (__PI__ / 180.0f));
+}
 
-#define foreach(T, c, i) for(T::iterator i = c.begin(); i!=c.end(); ++i)
+#define SPRITESTUDIO6DSK_foreach(T, c, i) for(T::iterator i = c.begin(); i!=c.end(); ++i)
 
+}	// namespace spritestudio6
 
 #endif

--- a/Common/Animator/ssplayer_matrix.cpp
+++ b/Common/Animator/ssplayer_matrix.cpp
@@ -5,6 +5,10 @@
 #include <memory.h>
 #include <math.h>
 
+namespace spritestudio6
+{
+
+
 void	IdentityMatrix( float* matrix )
 {
 
@@ -363,15 +367,15 @@ void 	SsOpenGLMatrix::inverseMatrix()
 	{
 		if (_matrix[i] > 0)
 		{
-			if ((0.000000000001) > _matrix[i] && _matrix[i] != 0)
+			if ((0.000000000001f) > _matrix[i] && _matrix[i] != 0)
 			{
-				_matrix[i] = 0.00001;
+				_matrix[i] = 0.00001f;
 			}
 		}
 		else {
-			if ((-0.000000000001) < _matrix[i] && _matrix[i] != 0)
+			if ((-0.000000000001f) < _matrix[i] && _matrix[i] != 0)
 			{
-				_matrix[i] = -0.00001;
+				_matrix[i] = -0.00001f;
 			}
 		}
 	}
@@ -417,7 +421,7 @@ void 	SsOpenGLMatrix::inverseMatrix()
 	{
 		for (j = 0; j< 4; j++)
 		{
-			_matrix[c] = inv_a[i][j];
+			_matrix[c] = (float)(inv_a[i][j]);
 			c++;
 		}
 	}
@@ -456,4 +460,4 @@ void  SsOpenGLMatrix::TransformVector3(SsVector3& src, SsVector3& dst)
 }
 
 
-
+}	// namespace spritestudio6

--- a/Common/Animator/ssplayer_matrix.h
+++ b/Common/Animator/ssplayer_matrix.h
@@ -4,6 +4,9 @@
 #include "SsTypes.h"
 #include <memory>
 
+namespace spritestudio6
+{
+
 void	IdentityMatrix( float* matrix );
 void    ScaleMatrix( float* _matrix , const float x , const float y , const float z);
 void    TranslationMatrix( float* _matrix , const float x , const float y , const float z );
@@ -160,6 +163,8 @@ private:
 
 };
 
+
+}	// namespace spritestudio6
 
 #endif
 

--- a/Common/Animator/ssplayer_mesh.cpp
+++ b/Common/Animator/ssplayer_mesh.cpp
@@ -7,7 +7,10 @@
 #include "ssplayer_mesh.h"
 #include "ssplayer_macro.h"
 #include "ssplayer_matrix.h"
-#include "ssplayer_animedecode.h"
+// #include "ssplayer_animedecode.h"
+
+namespace spritestudio6
+{
 
 
 void	SsMeshPart::makeMesh()
@@ -53,10 +56,10 @@ void	SsMeshPart::makeMesh()
 	offs.x -= targetCell->pivot.x * targetCell->size.x;
 	offs.y -= targetCell->pivot.y * targetCell->size.y;
 
-	ver_size = targetCell->meshPointList.size();
+	ver_size = (int)(targetCell->meshPointList.size());
 
-	float txsizew = this->targetTexture->getWidth();
-	float txsizeh = this->targetTexture->getHeight();
+	float txsizew = (float)(this->targetTexture->getWidth());
+	float txsizeh = (float)(this->targetTexture->getHeight());
 
 	float uvpixel_x = 1.0f / txsizew;
 	float uvpixel_y = 1.0f / txsizeh;
@@ -100,7 +103,7 @@ void	SsMeshPart::makeMesh()
 	}
 
 
-	tri_size = targetCell->meshTriList.size();
+	tri_size = (int)(targetCell->meshTriList.size());
 
 	indices = new unsigned short[tri_size * 3];
 	for (size_t i = 0; i < targetCell->meshTriList.size(); i++)
@@ -151,7 +154,7 @@ void	SsMeshPart::Cleanup()
 
 void    SsMeshPart::updateTransformMesh()
 {
-	float matrix[16];
+//	float matrix[16];
 	for (int i = 0; i < ver_size; i++)
 	{
 		StBoneWeight& info = bindBoneInfo[i];
@@ -379,7 +382,7 @@ void	SsMeshAnimator::update()
 {
 	if (bindAnime == 0)return;
 
-	foreach(std::vector<SsPartState*>, meshList, it)
+	SPRITESTUDIO6DSK_foreach(std::vector<SsPartState*>, meshList, it)
 	{
 		SsPartState* state = (*it);
 
@@ -459,3 +462,5 @@ void	SsMeshAnimator::modelLoad()
 
 
 }
+
+}	// namespace spritestudio6

--- a/Common/Animator/ssplayer_mesh.h
+++ b/Common/Animator/ssplayer_mesh.h
@@ -2,12 +2,16 @@
 #ifndef __SSPLAYER_MESH__
 #define __SSPLAYER_MESH__
 
+namespace spritestudio6
+{
 
 class ISSTexture;
 
-#define SSMESHPART_BONEMAX	(128)
-#define SSMESHPART_CHECKRANGE (4)
-
+enum
+{
+	SSMESHPART_BONEMAX = 128,
+	SSMESHPART_CHECKRANGE = 4,
+};
 struct StBoneWeight
 {
 	int		   		weight[SSMESHPART_BONEMAX];
@@ -148,5 +152,6 @@ public:
 
 
 
+}	// namespace spritestudio6
 
 #endif

--- a/Common/Animator/ssplayer_render.cpp
+++ b/Common/Animator/ssplayer_render.cpp
@@ -1,3 +1,8 @@
 ﻿#include "ssplayer_render.h"
 
+namespace spritestudio6
+{
+
 ISsRenderer*	SsCurrentRenderer::m_currentrender = 0;
+
+}	// namespace spritestudio6

--- a/Common/Animator/ssplayer_render.h
+++ b/Common/Animator/ssplayer_render.h
@@ -5,6 +5,8 @@
 #include "sstypes.h"
 
 
+namespace spritestudio6
+{
 
 struct SsPartState;
 struct SsCellValue;
@@ -56,5 +58,6 @@ public:
 };
 
 
+}	//	namespace spritestudio6
 
 #endif

--- a/Common/Animator/ssplayer_types.h
+++ b/Common/Animator/ssplayer_types.h
@@ -5,7 +5,10 @@
 #include "../Helper/ssHelper.h"
 
 
+namespace spritestudio6
+{
 
 
+}	// namespace spritestudio6
 
 #endif

--- a/Common/Animator/xorshift32.h
+++ b/Common/Animator/xorshift32.h
@@ -1,6 +1,8 @@
-﻿
-#ifndef __XORSHIFT32__
+﻿#ifndef __XORSHIFT32__
 #define __XORSHIFT32__
+
+namespace spritestudio6
+{
 
 #ifdef WIN32
 
@@ -44,6 +46,7 @@ public:
 } ;
 
 
+}	// namespace spritestudio6
 
 
 #endif

--- a/Common/Drawer/ssplayer_render_dx9.cpp
+++ b/Common/Drawer/ssplayer_render_dx9.cpp
@@ -10,6 +10,9 @@
 //#include "ssplayer_shader_gl.h"
 
 
+namespace spritestudio6
+{
+
 enum{
 	PG_SHADER_NPOT,
 	PG_SHADER_POT,
@@ -71,3 +74,5 @@ void	SsRenderDX9::renderPart( SsPartState* state )
 
 
 }
+
+}	// namespace spritestudio6

--- a/Common/Drawer/ssplayer_render_dx9.h
+++ b/Common/Drawer/ssplayer_render_dx9.h
@@ -3,6 +3,9 @@
 
 #include "ssplayer_render.h"
 
+namespace spritestudio6
+{
+
 struct SsPartState;
 
 class SsRenderDX9 : public ISsRenderer
@@ -36,5 +39,7 @@ public:
 
 
 };
+
+}	// namespace spritestudio6
 
 #endif

--- a/Common/Drawer/ssplayer_render_gl.cpp
+++ b/Common/Drawer/ssplayer_render_gl.cpp
@@ -22,10 +22,13 @@
 #include "ssplayer_cellmap.h"
 #include "ssplayer_mesh.h"
 
+#define SPRITESTUDIO6DSK_PROGRAMABLE_SHADER_ON (1)
+
+namespace spritestudio6
+{
+
 
 //ISsRenderer*	SsCurrentRenderer::m_currentrender = 0;
-
-#define PROGRAMABLE_SHADER_ON (1)
 
 static const char* glshader_sprite_vs = 
 #include "GLSL/sprite.vs";
@@ -832,7 +835,7 @@ void	SsRenderGL::renderPart( SsPartState* state )
 
 		glEnable(gl_target);
 
-#if PROGRAMABLE_SHADER_ON
+#if SPRITESTUDIO6DSK_PROGRAMABLE_SHADER_ON
 		if ( state->is_shader ) {
 			std::map<SsString, SSOpenGLProgramObject*>::const_iterator it = s_DefaultShaderMap.find( state->shaderValue.id );
 			if ( it != s_DefaultShaderMap.end() ) {
@@ -982,7 +985,7 @@ void	SsRenderGL::renderPart( SsPartState* state )
 				uvs[idx * 2] = state->cellValue.uvs[i].x * texturePixelSize.x;
 				uvs[idx * 2 + 1] = state->cellValue.uvs[i].y * texturePixelSize.y;
 
-#if USE_TRIANGLE_FIN
+#if SPRITESTUDIO6SDK_USE_TRIANGLE_FIN
 				//きれいな頂点変形への対応
 				uvs[4 * 2] += uvs[idx * 2];
 				uvs[4 * 2 + 1] += uvs[idx * 2 + 1];
@@ -993,7 +996,7 @@ void	SsRenderGL::renderPart( SsPartState* state )
 				uvs[idx * 2] = state->cellValue.uvs[i].x;
 				uvs[idx * 2 + 1] = state->cellValue.uvs[i].y;
 
-#if USE_TRIANGLE_FIN
+#if SPRITESTUDIO6SDK_USE_TRIANGLE_FIN
 				//きれいな頂点変形への対応
 				uvs[4 * 2] += uvs[idx * 2];
 				uvs[4 * 2 + 1] += uvs[idx * 2 + 1];
@@ -1018,7 +1021,7 @@ void	SsRenderGL::renderPart( SsPartState* state )
 			++uvorder;
 		}
 
-#if USE_TRIANGLE_FIN
+#if SPRITESTUDIO6SDK_USE_TRIANGLE_FIN
 		//きれいな頂点変形への対応
 		uvs[4*2]/=4.0f;
 		uvs[4*2+1]/=4.0f;
@@ -1097,7 +1100,7 @@ void	SsRenderGL::renderPart( SsPartState* state )
 				vertexID[i * 2 + 1] = i;
 			}
 
-#if USE_TRIANGLE_FIN
+#if SPRITESTUDIO6SDK_USE_TRIANGLE_FIN
 			// 中央頂点(index=4)のRGBA%値の計算
 			calcCenterVertexColor(state->colors, rates, vertexID);
 #else
@@ -1143,7 +1146,7 @@ void	SsRenderGL::renderPart( SsPartState* state )
 		//セルが無いので描画を行わない
 	}else{
 
-#if PROGRAMABLE_SHADER_ON
+#if SPRITESTUDIO6DSK_PROGRAMABLE_SHADER_ON
 
 	if ( state->is_shader )
 	{
@@ -1233,7 +1236,7 @@ void	SsRenderGL::renderPart( SsPartState* state )
 	}
 
 #endif
-#if USE_TRIANGLE_FIN
+#if SPRITESTUDIO6SDK_USE_TRIANGLE_FIN
 		if ( state->is_vertex_transform || state->is_parts_color)
 		{
 			static const GLubyte indices[] = { 4 , 3, 1, 0, 2 , 3};
@@ -1249,7 +1252,7 @@ void	SsRenderGL::renderPart( SsPartState* state )
 #endif
 	}
 
-#if PROGRAMABLE_SHADER_ON
+#if SPRITESTUDIO6DSK_PROGRAMABLE_SHADER_ON
 //	if ( glpgObject )
 	{
 		if ( state->is_shader )
@@ -1278,3 +1281,5 @@ void	SsRenderGL::renderPart( SsPartState* state )
 	glBlendEquation( GL_FUNC_ADD );
 
 }
+
+}	// namespace spritestudio6

--- a/Common/Drawer/ssplayer_render_gl.h
+++ b/Common/Drawer/ssplayer_render_gl.h
@@ -3,6 +3,9 @@
 
 #include "../Animator/ssplayer_render.h"
 
+namespace spritestudio6
+{
+
 struct SsPartState;
 class SsMeshPart;
 
@@ -39,5 +42,7 @@ public:
 
 
 };
+
+}	// namespace spritestudio6
 
 #endif

--- a/Common/Drawer/ssplayer_shader_gl.cpp
+++ b/Common/Drawer/ssplayer_shader_gl.cpp
@@ -12,6 +12,9 @@
 #include	<sstream>
 
 
+namespace spritestudio6
+{
+
 
 SSOpenGLProgramObject*			glpgObject = 0 ;
 SSOpenGLShaderMan*              SSOpenGLShaderMan::m_Myinst = 0;
@@ -263,7 +266,7 @@ SSOpenGLProgramObject::Use( void )
 {
 	glUseProgramObjectARB( h );
 	if ( glGetError() != GL_NO_ERROR ) {
-#if PUT_UNIFORM_WARNIG
+#if SPRITESTUDIO6DSK_PUT_UNIFORM_WARNIG
 //		SsLogInfo( _D("SSOpenGLProgramObject: glUseProgramObjectARB cannot use object\n") );
 #endif
 	}
@@ -271,3 +274,4 @@ SSOpenGLProgramObject::Use( void )
 
 
 
+}	// namespace spritestudio6

--- a/Common/Drawer/ssplayer_shader_gl.h
+++ b/Common/Drawer/ssplayer_shader_gl.h
@@ -4,8 +4,10 @@
 #include <string>
 #include <vector>
 
-#define PUT_UNIFORM_WARNIG	(1)
+#define SPRITESTUDIO6DSK_PUT_UNIFORM_WARNIG	(1)
 
+namespace spritestudio6
+{
 
 class	SSOpenGLShader {
 public:
@@ -123,6 +125,7 @@ public:
 int SsGL_CheckShaderReady( void );
 extern	SSOpenGLShaderMan*              glshaderMan;
 
+}	// namespace spritestudio6
 
 #endif
 

--- a/Common/Helper/DebugPrint.cpp
+++ b/Common/Helper/DebugPrint.cpp
@@ -12,6 +12,9 @@
 #endif
 
 
+namespace spritestudio6
+{
+
 
 void DEBUG_PRINTF( const char* strFormat, ...   )
 {
@@ -36,9 +39,12 @@ void DEBUG_PRINTF( const char* strFormat, ...   )
 void	THROW_ERROR_MESSAGE_MAIN( std::string str , char* fname , size_t line )
 {
 	char	___str__buffer[1024];
-	sprintf( ___str__buffer , "%s(%d) : %s \n" , fname , line , str.c_str() );
+	sprintf( ___str__buffer , "%s(%d) : %s \n" , fname , (int)line , str.c_str() );
 	std::string ___err_message = ___str__buffer;
 
 	DEBUG_PRINTF( ___str__buffer );
 	throw ThrowErrorMessage( 0 , ___err_message );
 }
+
+
+}	// namespace spritestudio6

--- a/Common/Helper/DebugPrint.h
+++ b/Common/Helper/DebugPrint.h
@@ -3,6 +3,8 @@
 
 #include <string>
 
+namespace spritestudio6
+{
 
 void DEBUG_PRINTF( const char* strFormat, ...   );
 
@@ -13,14 +15,15 @@ struct ThrowErrorMessage{
 	ThrowErrorMessage( int no , std::string str ){ error_no = no ; message = str; }
 };
 
-
-#define THROW_ERROR_MESSAGE(str) \
+// MEMO: 外部名前空間からアクセスされた時の防備で、念のため完全修飾してあります。
+#define SPRITESTUDIO6DSK_THROW_ERROR_MESSAGE(str) \
 {\
-THROW_ERROR_MESSAGE_MAIN( str , __FILE__ , __LINE__ );\
+spritestudio6::THROW_ERROR_MESSAGE_MAIN( str , __FILE__ , __LINE__ );\
 }\
 
 void	THROW_ERROR_MESSAGE_MAIN( std::string str , char* fname , size_t line );
 
 
+}	// namespace spritestudio6
 
 #endif

--- a/Common/Helper/DirectX/SSTextureDX9.cpp
+++ b/Common/Helper/DirectX/SSTextureDX9.cpp
@@ -6,6 +6,9 @@
 #include "ssHelper.h"
 #include "SSTextureDX9.h"
 
+namespace spritestudio6
+{
+
 #if 0
 /* =====================================================================================
 	テクスチャファイルの読み込み
@@ -63,3 +66,5 @@ bool SSTextureDX9::Load( const char* filename )
 
 	return true;
 }
+
+}	// namespace spritestudio6

--- a/Common/Helper/DirectX/SSTextureDX9.h
+++ b/Common/Helper/DirectX/SSTextureDX9.h
@@ -4,6 +4,9 @@
 
 #include "IsshTexture.h"
 
+namespace spritestudio6
+{
+
 //テクスチャクラス ( DirectX9 )
 class	SSTextureDX9 : public ISSTexture
 {
@@ -23,9 +26,7 @@ public:
 };
 
 
-
-
-
+}	// namespace spritestudio6
 
 
 #endif

--- a/Common/Helper/DirectX/d3dsimple.cpp
+++ b/Common/Helper/DirectX/d3dsimple.cpp
@@ -100,14 +100,14 @@ void	CDirectDrawSimple::DeviceReset()
 				//m_DeviceLost = true;
 				return ;
 			}else if( hr == D3DERR_DEVICENOTRESET ){
-				//THROW_ERROR_MESSAGE( "Error : D3DERR_DEVICENOTRESET" );
+				//SPRITESTUDIO6DSK_THROW_ERROR_MESSAGE( "Error : D3DERR_DEVICENOTRESET" );
 				return ;					
 			}else if ( hr == D3DERR_INVALIDCALL )
 			{
-				//THROW_ERROR_MESSAGE( "Error : D3DERR_INVALIDCALL" );
+				//SPRITESTUDIO6DSK_THROW_ERROR_MESSAGE( "Error : D3DERR_INVALIDCALL" );
 				return ;
 			}else{
-				//THROW_ERROR_MESSAGE( "Error : DirectX Reset" );
+				//SPRITESTUDIO6DSK_THROW_ERROR_MESSAGE( "Error : DirectX Reset" );
 				return ;
 			}
 		}

--- a/Common/Helper/IsshTexture.cpp
+++ b/Common/Helper/IsshTexture.cpp
@@ -2,6 +2,9 @@
 #include "IsshTexture.h"
 #include "../Helper/DebugPrint.h"
 
+namespace spritestudio6
+{
+
 
 ISSTexture*	SSTextureFactory::m_texture_base_class = 0;
 SSTextureFactory*	SSTextureFactory::m_myInst = 0;
@@ -124,3 +127,6 @@ void SSTextureFactory::releaseAllTexture()
 	}
 	m_myInst->textureCache.clear();
 }
+
+
+}	// namespace spritestudio6

--- a/Common/Helper/IsshTexture.h
+++ b/Common/Helper/IsshTexture.h
@@ -4,6 +4,9 @@
 #include "../Loader/sstypes.h"
 #include <map>
 
+namespace spritestudio6
+{
+
 
 // nが2のべき乗かどうかチェックする
 inline bool SsUtTextureisPow2(int n)
@@ -95,6 +98,7 @@ public:
 };
 
 
+}	// namespace spritestudio6
 
 #endif //ifdef __ISSGraphTexture__
 

--- a/Common/Helper/MacOS/OSXFileOpen.h
+++ b/Common/Helper/MacOS/OSXFileOpen.h
@@ -30,4 +30,5 @@ public:
 #endif
 
 //void    testOpenDlg();
+
 #endif

--- a/Common/Helper/MacOS/OSXFileOpen.mm
+++ b/Common/Helper/MacOS/OSXFileOpen.mm
@@ -14,7 +14,6 @@
 #import <AppKit/NSOpenPanel.h>
 #import <Foundation/Foundation.h>
 
-
 extern void GlContexMakeCurrent();
 
 bool MacOSXFileOpenDlg::show()
@@ -45,8 +44,5 @@ bool MacOSXFileOpenDlg::show()
     GlContexMakeCurrent();
     return false;
 }
-
-
-
 
 #endif

--- a/Common/Helper/OpenGL/SSTextureGL.cpp
+++ b/Common/Helper/OpenGL/SSTextureGL.cpp
@@ -15,6 +15,9 @@
 #include "SSTextureGL.h"
 
 
+namespace spritestudio6
+{
+
 /* =====================================================================================
 	テクスチャファイルの読み込み
 ===================================================================================== */
@@ -92,3 +95,5 @@ bool SSTextureGL::Load( const char* fname )
 	tex = LoadTextureGL( fname , tex_width , tex_height );
 	return tex != 0;
 }
+
+}	// namespace spritestudio6

--- a/Common/Helper/OpenGL/SSTextureGL.h
+++ b/Common/Helper/OpenGL/SSTextureGL.h
@@ -3,6 +3,8 @@
 
 #include "../IsshTexture.h"
 
+namespace spritestudio6
+{
 
 class	SSTextureGL : public ISSTexture
 {
@@ -26,7 +28,6 @@ public:
 
 
 
-
-
+}	// namespace spritestudio6
 
 #endif

--- a/Common/Helper/XPFileOpenDlg.cpp
+++ b/Common/Helper/XPFileOpenDlg.cpp
@@ -25,6 +25,10 @@
 	#include "string"
 #endif
 
+namespace spritestudio6
+{
+
+
 bool XPFileOpenDlg::Show()
 {	
 #ifdef _WIN32
@@ -73,3 +77,6 @@ bool XPFileOpenDlg::Show()
 
     return false;
 }
+
+
+}	// namespace spritestudio6

--- a/Common/Helper/XPFileOpenDlg.h
+++ b/Common/Helper/XPFileOpenDlg.h
@@ -11,6 +11,9 @@
 #ifndef __XP_FILEOPENDLG__
 #define __XP_FILEOPENDLG__
 
+namespace spritestudio6
+{
+
 class XPFileOpenDlg {
 private:
 	char*	pszChar;
@@ -26,5 +29,8 @@ public:
 	const char* getFilePath(){ return pszChar;}
 
 };
+
+
+}	// namespace spritestudio6
 
 #endif

--- a/Common/Helper/ssHelper.h
+++ b/Common/Helper/ssHelper.h
@@ -12,5 +12,4 @@
 #include "XPFileOpenDlg.h"
 #include "DebugPrint.h"
 
-
 #endif

--- a/Common/Helper/sshObject.cpp
+++ b/Common/Helper/sshObject.cpp
@@ -1,2 +1,9 @@
 ﻿#include "sshObject.h"
 
+namespace spritestudio6
+{
+
+
+
+
+}	// namespace spritestudio6

--- a/Common/Helper/sshObject.h
+++ b/Common/Helper/sshObject.h
@@ -3,6 +3,9 @@
 
 #include "sshTask.h"
 
+namespace spritestudio6
+{
+
 
 class	tkObject : public task_base{
 public:
@@ -11,5 +14,6 @@ public:
 };
 
 
+}	// namespace spritestudio6
 
 #endif

--- a/Common/Helper/sshScene.cpp
+++ b/Common/Helper/sshScene.cpp
@@ -1,1 +1,7 @@
 ﻿#include "sshScene.h"
+
+namespace spritestudio6
+{
+
+
+}	// namespace spritestudio6

--- a/Common/Helper/sshScene.h
+++ b/Common/Helper/sshScene.h
@@ -4,6 +4,10 @@
 
 #include "sshObject.h"
 
+namespace spritestudio6
+{
+
+
 ///シーングラフを構築するためのクラス
 ///色々オミットする シーンを既定できればOK
 class	tkScene : public tkObject
@@ -19,6 +23,6 @@ public:
 
 
 
+}	// namespace spritestudio6
 
 #endif
-

--- a/Common/Helper/sshTask.cpp
+++ b/Common/Helper/sshTask.cpp
@@ -2,6 +2,10 @@
 #include "sshTask.h"
 //#include "Debug.h"
 
+namespace spritestudio6
+{
+
+
 task_manager_singleton* task_manager_singleton::g_myinst = 0;
 unsigned long	treeitem_uid::m_tree_item_uid	 = 0;
 
@@ -128,3 +132,4 @@ void	task_manager::debug_print_tasks()
 */
 
 
+}	// namespace spritestudio6

--- a/Common/Helper/sshTask.h
+++ b/Common/Helper/sshTask.h
@@ -8,6 +8,9 @@
 #include <vector>
 #include <list>
 
+namespace spritestudio6
+{
+
 class	treeitem_uid
 {
 private:
@@ -321,5 +324,7 @@ inline	void task_manager_destroy()
 	}
 }
 
+
+}	// namespace spritestudio6
 
 #endif

--- a/Common/Helper/sshTextureBMP.cpp
+++ b/Common/Helper/sshTextureBMP.cpp
@@ -5,6 +5,9 @@
 #include "ssHelper.h"
 #include "sshTextureBMP.h"
 
+namespace spritestudio6
+{
+
 
 
 
@@ -28,3 +31,7 @@ bool SSTextureBMP::Load( const char* fname )
 	stbi_image_free (image);
 	return true;
 }
+
+
+
+}	// namespace spritestudio6

--- a/Common/Helper/sshTextureBMP.h
+++ b/Common/Helper/sshTextureBMP.h
@@ -3,6 +3,8 @@
 
 #include "IsshTexture.h"
 
+namespace spritestudio6
+{
 
 
 //画像ファイルの縦横サイズを調べる目的等で使用する
@@ -33,5 +35,6 @@ public:
 
 
 
+}	// namespace spritestudio6
 
 #endif

--- a/Common/Loader/SsEffectBehavior.cpp
+++ b/Common/Loader/SsEffectBehavior.cpp
@@ -1,9 +1,10 @@
 ﻿#include "SsEffectBehavior.h"
 
 
+namespace spritestudio6
+{
 
-
-SsEffectElementBase*	SsEffectBehavior::Factory(const char* name , XMLElement* e )
+SsEffectElementBase*	SsEffectBehavior::Factory(const char* name , libXML::XMLElement* e )
 {
 	SsEffectElementBase * ret = 0;
 
@@ -40,7 +41,7 @@ void	SsEffectBehavior::EffectElementLoader(ISsXmlArchiver* ar)
 {
 	SsXmlIArchiver list_ar( ar , "list" );
 
-	XMLElement* e = list_ar.getxml()->FirstChildElement();
+	libXML::XMLElement* e = list_ar.getxml()->FirstChildElement();
 
 	while( e )
 	{
@@ -56,3 +57,6 @@ void	SsEffectBehavior::EffectElementLoader(ISsXmlArchiver* ar)
 	}
 
 }
+
+}	// namespace spritestudio6
+

--- a/Common/Loader/SsEffectBehavior.h
+++ b/Common/Loader/SsEffectBehavior.h
@@ -5,6 +5,9 @@
 #include "sstypes.h"
 #include "ssvalue.h"
 
+namespace spritestudio6
+{
+
 class SsEffectElementBase;
 class SsEffectRenderer;
 
@@ -23,17 +26,17 @@ public:
 	SsEffectBehavior() : refCell(0),BlendType(SsRenderBlendType::invalid) {}
 	virtual ~SsEffectBehavior(){}
 
-	SSSERIALIZE_BLOCK
+	SPRITESTUDIO6DSK_SERIALIZE_BLOCK
 	{
-		SSAR_DECLARE(CellName);
-		SSAR_DECLARE(CellMapName);
-		SSAR_DECLARE_ENUM( BlendType );
+		SPRITESTUDIO6DSK_SSAR_DECLARE(CellName);
+		SPRITESTUDIO6DSK_SSAR_DECLARE(CellMapName);
+		SPRITESTUDIO6DSK_SSAR_DECLARE_ENUM( BlendType );
 
 		if ( ar->getxml() )
 			EffectElementLoader( ar );
 	}
 
-	SsEffectElementBase*	Factory(const char* name , XMLElement* e );
+	SsEffectElementBase*	Factory(const char* name , libXML::XMLElement* e );
 
 	void	EffectElementLoader(ISsXmlArchiver* ar);
 	void	setup();
@@ -51,6 +54,6 @@ public:
 
 
 
-
+}	// namespace spritestudio6
 
 #endif

--- a/Common/Loader/SsEffectElement.cpp
+++ b/Common/Loader/SsEffectElement.cpp
@@ -14,5 +14,9 @@
 #include "ssplayer_render.h"
 #include "ssplayer_effectfunction.h"
 
+namespace spritestudio6
+{
 
+
+}	// namespace spritestudio6
 

--- a/Common/Loader/SsEffectElement.h
+++ b/Common/Loader/SsEffectElement.h
@@ -5,6 +5,9 @@
 #include "sstypes.h"
 #include "ssarchiver.h"
 
+namespace spritestudio6
+{
+
 enum EffectPartType
 {
 	EffectPartTypeEmiiter,
@@ -39,7 +42,6 @@ namespace SsEffectFunctionType
 		InfiniteEmitEnabled,
 	};
 }
-
 
 class SsCell;
 
@@ -166,7 +168,7 @@ public:
 #endif
 	//シリアライザ
 
-	virtual SSSERIALIZE_BLOCK
+	virtual SPRITESTUDIO6DSK_SERIALIZE_BLOCK
 	{
 		ar = ar;
 	}
@@ -211,17 +213,17 @@ public:
 	virtual void InitializeParticle( SsEffectRenderEmitter* e , SsEffectRenderParticle* particle );
 	virtual void UpdateParticle( SsEffectRenderParticle* particle ){}
 */
-	SSSERIALIZE_BLOCK
+	SPRITESTUDIO6DSK_SERIALIZE_BLOCK
 	{
-		SSAR_DECLARE( maximumParticle );
-		SSAR_DECLARE( speed );
-		SSAR_DECLARE( lifespan );
-		SSAR_DECLARE( angle );
-		SSAR_DECLARE( angleVariance );
-		SSAR_DECLARE( interval );
-		SSAR_DECLARE( lifetime );
-		SSAR_DECLARE( attimeCreate );
-		SSAR_DECLARE( priority );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( maximumParticle );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( speed );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( lifespan );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( angle );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( angleVariance );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( interval );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( lifetime );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( attimeCreate );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( priority );
 	}
 
 };
@@ -247,9 +249,9 @@ public:
 */
 
 	//シリアライザ
-	SSSERIALIZE_BLOCK
+	SPRITESTUDIO6DSK_SERIALIZE_BLOCK
 	{
-		SSAR_DECLARE( Seed );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( Seed );
 	}
 
 };
@@ -277,9 +279,9 @@ public:
 
 	virtual void UpdateEndEmmiter( SsEffectRenderEmitter* emmiter );
 */
-	SSSERIALIZE_BLOCK
+	SPRITESTUDIO6DSK_SERIALIZE_BLOCK
 	{
-		SSAR_DECLARE( DelayTime );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( DelayTime );
 	}
 
 
@@ -306,9 +308,9 @@ public:
 	virtual void InitializeParticle( SsEffectRenderEmitter* e , SsEffectRenderParticle* particle );
 	virtual void UpdateParticle( SsEffectRenderParticle* particle );
 */
-	SSSERIALIZE_BLOCK
+	SPRITESTUDIO6DSK_SERIALIZE_BLOCK
 	{
-		SSAR_DECLARE( Gravity );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( Gravity );
 	}
 
 };
@@ -332,10 +334,10 @@ public:
 	virtual    SsEffectElementBase*  new_(){ return new ParticleElementPosition(); }
 	virtual void InitializeParticle( SsEffectRenderEmitter* e , SsEffectRenderParticle* particle );
 */
-	SSSERIALIZE_BLOCK
+	SPRITESTUDIO6DSK_SERIALIZE_BLOCK
 	{
-		SSAR_DECLARE( OffsetX );
-		SSAR_DECLARE( OffsetY );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( OffsetX );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( OffsetY );
 	}
 
 
@@ -362,10 +364,10 @@ public:
 	virtual    SsEffectElementBase*  new_(){ return new ParticleElementTransPosition(); }
 	virtual void InitializeParticle( SsEffectRenderEmitter* e , SsEffectRenderParticle* particle ){}
 	*/
-	SSSERIALIZE_BLOCK
+	SPRITESTUDIO6DSK_SERIALIZE_BLOCK
 	{
-		SSAR_DECLARE( OffsetX );
-		SSAR_DECLARE( OffsetY );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( OffsetX );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( OffsetY );
 	}
 
 };
@@ -394,10 +396,10 @@ public:
 	virtual void UpdateParticle( SsEffectRenderParticle* particle );
 */
 	//シリアライザ
-	SSSERIALIZE_BLOCK
+	SPRITESTUDIO6DSK_SERIALIZE_BLOCK
 	{
-		SSAR_DECLARE( Rotation );
-		SSAR_DECLARE( RotationAdd );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( Rotation );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( RotationAdd );
 	}
 
 
@@ -424,10 +426,10 @@ public:
 	virtual void InitializeParticle( SsEffectRenderEmitter* e , SsEffectRenderParticle* particle );
  	virtual void UpdateParticle( SsEffectRenderParticle* particle );
 */
-	SSSERIALIZE_BLOCK
+	SPRITESTUDIO6DSK_SERIALIZE_BLOCK
 	{
-		SSAR_DECLARE( RotationFactor );
-		SSAR_DECLARE( EndLifeTimePer );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( RotationFactor );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( EndLifeTimePer );
 	}
 
 
@@ -451,9 +453,9 @@ public:
 	virtual void InitializeParticle( SsEffectRenderEmitter* e , SsEffectRenderParticle* particle );
  	virtual void UpdateParticle( SsEffectRenderParticle* particle );
 */
-	SSSERIALIZE_BLOCK
+	SPRITESTUDIO6DSK_SERIALIZE_BLOCK
 	{
-		SSAR_DECLARE( Speed );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( Speed );
 	}
 };
 
@@ -477,9 +479,9 @@ public:
 
 	virtual void InitializeParticle( SsEffectRenderEmitter* e , SsEffectRenderParticle* particle );
 */
-	SSSERIALIZE_BLOCK
+	SPRITESTUDIO6DSK_SERIALIZE_BLOCK
 	{
-		SSAR_DECLARE( Acceleration );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( Acceleration );
 	}
 
 };
@@ -503,9 +505,9 @@ public:
 	virtual void InitializeParticle( SsEffectRenderEmitter* e , SsEffectRenderParticle* particle );
 	virtual void UpdateParticle( SsEffectRenderParticle* particle );
 */
-	SSSERIALIZE_BLOCK
+	SPRITESTUDIO6DSK_SERIALIZE_BLOCK
 	{
-		SSAR_DECLARE( Color );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( Color );
 	}
 };
 
@@ -527,9 +529,9 @@ public:
 	virtual void InitializeParticle( SsEffectRenderEmitter* e , SsEffectRenderParticle* particle );
 	virtual void UpdateParticle( SsEffectRenderParticle* particle );
 */
-	SSSERIALIZE_BLOCK
+	SPRITESTUDIO6DSK_SERIALIZE_BLOCK
 	{
-		SSAR_DECLARE( Color );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( Color );
 	}
 
 };
@@ -554,9 +556,9 @@ public:
 	virtual void InitializeParticle( SsEffectRenderEmitter* e , SsEffectRenderParticle* particle );
 	virtual void UpdateParticle( SsEffectRenderParticle* particle );
 */
-	SSSERIALIZE_BLOCK
+	SPRITESTUDIO6DSK_SERIALIZE_BLOCK
 	{
-		SSAR_DECLARE( disprange );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( disprange );
 	}
 
 
@@ -584,11 +586,11 @@ public:
 	virtual void InitializeParticle( SsEffectRenderEmitter* e , SsEffectRenderParticle* particle );
 	virtual void UpdateParticle( SsEffectRenderParticle* particle );
 */
-	SSSERIALIZE_BLOCK
+	SPRITESTUDIO6DSK_SERIALIZE_BLOCK
 	{
-		SSAR_DECLARE( SizeX );
-		SSAR_DECLARE( SizeY );
-		SSAR_DECLARE( ScaleFactor );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( SizeX );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( SizeY );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( ScaleFactor );
 	}
 
 
@@ -618,11 +620,11 @@ public:
 	virtual void InitializeParticle( SsEffectRenderEmitter* e , SsEffectRenderParticle* particle );
 	virtual void UpdateParticle( SsEffectRenderParticle* particle );
 */
-	SSSERIALIZE_BLOCK
+	SPRITESTUDIO6DSK_SERIALIZE_BLOCK
 	{
-		SSAR_DECLARE( SizeX );
-		SSAR_DECLARE( SizeY );
-		SSAR_DECLARE( ScaleFactor );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( SizeX );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( SizeY );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( ScaleFactor );
 	}
 
 };
@@ -655,10 +657,10 @@ public:
 	virtual void UpdateParticle( SsEffectRenderParticle* particle );
 */
 
-	SSSERIALIZE_BLOCK
+	SPRITESTUDIO6DSK_SERIALIZE_BLOCK
 	{
-		SSAR_DECLARE( Position );
-		SSAR_DECLARE( Power );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( Position );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( Power );
 	}
 
 };
@@ -690,9 +692,9 @@ public:
 	virtual void InitializeParticle( SsEffectRenderEmitter* e , SsEffectRenderParticle* particle );
 	virtual void UpdateParticle( SsEffectRenderParticle* particle ){}
 */
-	SSSERIALIZE_BLOCK
+	SPRITESTUDIO6DSK_SERIALIZE_BLOCK
 	{
-		SSAR_DECLARE( Rotation );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( Rotation );
 	}
 };
 
@@ -708,7 +710,7 @@ public:
 	}
 	virtual ~ParticleInfiniteEmitEnabled(){}
 
-	SSSERIALIZE_BLOCK
+	SPRITESTUDIO6DSK_SERIALIZE_BLOCK
 	{
 
 	}
@@ -717,6 +719,6 @@ public:
 
 
 
-
+}	// namespace spritestudio6
 
 #endif

--- a/Common/Loader/ssInterpolation.cpp
+++ b/Common/Loader/ssInterpolation.cpp
@@ -1,7 +1,8 @@
 ﻿#include "ssloader.h"
 #include "ssInterpolation.h"
 
-
+namespace spritestudio6
+{
 
 //---------------------------------------------------------------------------
 /**
@@ -166,3 +167,5 @@ float	SsInterpolate(SsInterpolationType::_enum type, float time, float start, fl
 	}
 	return r;
 }
+
+}	// namespace spritestudio6

--- a/Common/Loader/ssInterpolation.h
+++ b/Common/Loader/ssInterpolation.h
@@ -1,6 +1,8 @@
 ﻿#ifndef __SSINTERPOLATION__
 #define __SSINTERPOLATION__
 
+namespace spritestudio6
+{
 
 class SsCurve;
 
@@ -19,5 +21,8 @@ inline bool SsNeedsCurveParams(SsInterpolationType::_enum type)
 ///カーブパラメータ、補完方法により保管された値を生成する
 SsVector2	SsInterpolate(SsInterpolationType::_enum ipType, float time, SsVector2 start, SsVector2 end, const SsCurve * curve);
 float	SsInterpolate(SsInterpolationType::_enum type, float time, float start, float end, const SsCurve * curve);
+
+
+}	// namespace spritestudio6
 
 #endif

--- a/Common/Loader/ssarchiver.cpp
+++ b/Common/Loader/ssarchiver.cpp
@@ -2,9 +2,12 @@
 #include "ssstring_uty.h"
 #include "sscharconverter.h"
 
+namespace spritestudio6
+{
+
 bool	SsXmlIArchiver::dc_attr( const char* name , SsString& member )
 {
-	AR_SELF_CHECK();
+	SPRITESTUDIO6DSK_AR_SELF_CHECK();
 	const char* v = 0;
 
 	v = getxml()->Attribute( name  );
@@ -15,7 +18,7 @@ bool	SsXmlIArchiver::dc_attr( const char* name , SsString& member )
 }
 bool	SsXmlIArchiver::dc_attr( const char* name , int& member )
 {
-	AR_SELF_CHECK();
+	SPRITESTUDIO6DSK_AR_SELF_CHECK();
 
 	const char* v = getxml()->Attribute( name  );
 
@@ -27,7 +30,7 @@ bool	SsXmlIArchiver::dc_attr( const char* name , int& member )
 bool	SsXmlIArchiver::dc( const char* name , int& member )
 {
 
-	AR_SELF_CHECK();
+	SPRITESTUDIO6DSK_AR_SELF_CHECK();
 	SsString str;
 	dc( name , str );
 	member = atoi( str.c_str() );
@@ -41,7 +44,7 @@ bool	SsXmlIArchiver::dc( const char* name , int& member )
 
 bool	SsXmlIArchiver::dc( const char* name , float& member )
 {
-	AR_SELF_CHECK();
+	SPRITESTUDIO6DSK_AR_SELF_CHECK();
 	SsString str;
 	dc( name , str );
 	member = (float)atof( str.c_str() );
@@ -55,8 +58,8 @@ bool	SsXmlIArchiver::dc( const char* name , float& member )
 
 bool	SsXmlIArchiver::dc( const char* name , SsString& member )
 {
-	AR_SELF_CHECK();
-	XMLElement* e = getxml()->FirstChildElement( name );
+	SPRITESTUDIO6DSK_AR_SELF_CHECK();
+	libXML::XMLElement* e = getxml()->FirstChildElement( name );
 	if ( e )
 	{
 		if ( e->GetText() )
@@ -72,9 +75,9 @@ bool	SsXmlIArchiver::dc( const char* name , SsString& member )
 
 bool	SsXmlIArchiver::dc( const char* name , bool& member )
 {
-	AR_SELF_CHECK();
+	SPRITESTUDIO6DSK_AR_SELF_CHECK();
 	member = false;
-	XMLElement* e = getxml()->FirstChildElement( name );
+	libXML::XMLElement* e = getxml()->FirstChildElement( name );
 	if ( e )
 	{
 		int ret = GetTextToInt( e , 0 );
@@ -88,9 +91,9 @@ bool	SsXmlIArchiver::dc( const char* name , bool& member )
 
 bool	SsXmlIArchiver::dc(const char* name, std::vector<SsPoint2>& list)
 {
-	AR_SELF_CHECK();
+	SPRITESTUDIO6DSK_AR_SELF_CHECK();
 	list.clear();
-	XMLElement* e = getxml()->FirstChildElement(name);
+	libXML::XMLElement* e = getxml()->FirstChildElement(name);
 	if (e == 0)return false;
 	e = e->FirstChildElement("value");
 	while (e)
@@ -108,9 +111,9 @@ bool	SsXmlIArchiver::dc(const char* name, std::vector<SsPoint2>& list)
 
 bool	SsXmlIArchiver::dc(const char* name, std::vector<SsTriangle>& list)
 {
-	AR_SELF_CHECK();
+	SPRITESTUDIO6DSK_AR_SELF_CHECK();
 	list.clear();
-	XMLElement* e = getxml()->FirstChildElement(name);
+	libXML::XMLElement* e = getxml()->FirstChildElement(name);
 	if (e == 0)return false;
 	e = e->FirstChildElement("value");
 	while (e)
@@ -128,9 +131,9 @@ bool	SsXmlIArchiver::dc(const char* name, std::vector<SsTriangle>& list)
 
 bool	SsXmlIArchiver::dc( const char* name , std::vector<SsString>& list )
 {
-	AR_SELF_CHECK();
+	SPRITESTUDIO6DSK_AR_SELF_CHECK();
 	list.clear();
-	XMLElement* e = getxml()->FirstChildElement( name );
+	libXML::XMLElement* e = getxml()->FirstChildElement( name );
 	if (e==0)return false;
 	e = e->FirstChildElement( "value" );
 	while( e )
@@ -147,9 +150,9 @@ bool	SsXmlIArchiver::dc( const char* name , std::vector<SsString>& list )
 
 bool	SsXmlIArchiver::dc( const char* name , SsPoint2& member )
 {
-	AR_SELF_CHECK();
+	SPRITESTUDIO6DSK_AR_SELF_CHECK();
 
-	XMLElement* e = getxml()->FirstChildElement( name );
+	libXML::XMLElement* e = getxml()->FirstChildElement( name );
 
 	if ( e )
 	{
@@ -163,9 +166,9 @@ bool	SsXmlIArchiver::dc( const char* name , SsPoint2& member )
 
 bool	SsXmlIArchiver::dc( const char* name , SsCurve& member )
 {
-	AR_SELF_CHECK();
+	SPRITESTUDIO6DSK_AR_SELF_CHECK();
 
-	XMLElement* e = getxml()->FirstChildElement( name );
+	libXML::XMLElement* e = getxml()->FirstChildElement( name );
 
 	if ( e )
 	{
@@ -188,9 +191,9 @@ bool	SsXmlIArchiver::dc( const char* name , SsCurve& member )
 
 bool	SsXmlIArchiver::dc(const char* name, SsTriangle& member)
 {
-	AR_SELF_CHECK();
+	SPRITESTUDIO6DSK_AR_SELF_CHECK();
 
-	XMLElement* e = getxml()->FirstChildElement(name);
+	libXML::XMLElement* e = getxml()->FirstChildElement(name);
 
 	if (e)
 	{
@@ -217,9 +220,9 @@ bool	SsXmlIArchiver::dc(const char* name, SsTriangle& member)
 /*
 bool	SsXmlIArchiver::dc(const char* name, SsBoneBind& member)
 {
-	AR_SELF_CHECK();
+	SPRITESTUDIO6DSK_AR_SELF_CHECK();
 
-	XMLElement* e = getxml()->FirstChildElement(name);
+	libXML::XMLElement* e = getxml()->FirstChildElement(name);
 
 	if (e)
 	{
@@ -246,7 +249,7 @@ bool	SsXmlIArchiver::dc(const char* name, std::map<SsString, int>& _map)
 {
 	_map.clear();
 
-	XMLElement* e = getxml()->FirstChildElement(name);
+	libXML::XMLElement* e = getxml()->FirstChildElement(name);
 	if (e == 0)return false;
 	e = e->FirstChildElement("item");
 
@@ -325,3 +328,5 @@ bool	StringToIRect( const std::string& str , SsIRect& rect )
 void	SsArchiverInit()
 {
 }
+
+}	// namespace spritestudio6

--- a/Common/Loader/ssarchiver.h
+++ b/Common/Loader/ssarchiver.h
@@ -7,12 +7,19 @@
 #include <vector>
 #include <map>
 
-using namespace tinyxml2;
+// MEMO: 定義順の関係でここでusingしてしまうと問題が発生する
+// using namespace tinyxml2;
 
+namespace spritestudio6
+{
 
+// MEMO: 後に入れ替え可能なようにエリアスで定義しておく。
+namespace libXML = tinyxml2;
 
 /// シリアライズクラスのInput/Outputの状態
-struct EnumSsArchiver
+// MEMO: 元はstructでの定義だったのだが、記述意図から類推すると恐らくtypesafeのためだと思われるため、念のためnamespaceに変更。
+// struct EnumSsArchiver
+namespace EnumSsArchiver
 {
 	enum Type
 	{
@@ -39,7 +46,7 @@ public:
 class ISsXmlArchiver
 {
 private:
-	XMLElement*		m_xml;
+	libXML::XMLElement*	m_xml;
 
 public:
 
@@ -49,19 +56,19 @@ public:
 	ISsXmlArchiver(){}
 	virtual ~ISsXmlArchiver(){}
 
-	XMLElement*	getxml(){ return m_xml;} 
+	libXML::XMLElement*	getxml(){ return m_xml;} 
 
 	void	firstChild(ISsXmlArchiver* ar , const char* element_name)
 	{
 		m_xml = ar->getxml()->FirstChildElement( element_name );
 	}
 
-	void	setDocumet( tinyxml2::XMLDocument* doc , const char* element_name)
+	void	setDocumet( libXML::XMLDocument* doc , const char* element_name)
 	{
 		m_xml = doc->FirstChildElement(element_name);
 	}
 
-	void	setElement(XMLElement* e )
+	void	setElement(libXML::XMLElement* e )
 	{
 		m_xml = e;
 	}
@@ -89,7 +96,7 @@ public:
 };
 
 
-inline	static int	GetTextToInt(XMLElement* e , int default_value )
+inline	static int	GetTextToInt(libXML::XMLElement* e , int default_value )
 {
 	int ret =default_value; 
 	const char* v = e->GetText();
@@ -112,12 +119,12 @@ public:
 	{
 		firstChild( ar , element_name );
 	}
-	SsXmlIArchiver( tinyxml2::XMLDocument* doc , const char* element_name)
+	SsXmlIArchiver( libXML::XMLDocument* doc , const char* element_name)
 	{
 		setDocumet( doc , element_name );
 	}
 
-	SsXmlIArchiver(XMLElement* e )
+	SsXmlIArchiver(libXML::XMLElement* e )
 	{
 		setElement( e );
 	}
@@ -138,7 +145,7 @@ public:
 	
 	virtual bool	dc( const char* name , SsXmlRangeValueConverter& member )
 	{
-		XMLElement* e = getxml()->FirstChildElement( name );
+		libXML::XMLElement* e = getxml()->FirstChildElement( name );
 		SsXmlIArchiver _ar(e);
 
 		SsString str;
@@ -165,7 +172,7 @@ public:
 	template<class myclass> bool	dc( const char* name , std::vector<myclass*>& list , const std::string key = "value" )
 	{
 		list.clear();
-		XMLElement* e = getxml()->FirstChildElement( name );
+		libXML::XMLElement* e = getxml()->FirstChildElement( name );
 		if (e == 0)return false;
 		if ( key != "" )
 			e = e->FirstChildElement( key.c_str() );
@@ -203,12 +210,12 @@ public:
 };
 
 
-#define SSSERIALIZE_BLOCK	void __Serialize(ISsXmlArchiver* ar)
+#define SPRITESTUDIO6DSK_SERIALIZE_BLOCK	void __Serialize(ISsXmlArchiver* ar)
 
-#define	SSAR_DECLARE(t)  ar->dc(#t,t)
-#define	SSAR_DECLARE_ATTRIBUTE(t)  ar->dc_attr(#t,t)
+#define	SPRITESTUDIO6DSK_SSAR_DECLARE(t)  ar->dc(#t,t)
+#define	SPRITESTUDIO6DSK_SSAR_DECLARE_ATTRIBUTE(t)  ar->dc_attr(#t,t)
 
-#define	SSAR_STRUCT_DECLARE(t)  {SsXmlIArchiver _ar( ar , #t );\
+#define	SPRITESTUDIO6DSK_SSAR_STRUCT_DECLARE(t)  {SsXmlIArchiver _ar( ar , #t );\
 t.__Serialize( &_ar );}\
 
 template<class myclass>
@@ -227,9 +234,9 @@ inline bool	__SSAR_DECLARE_LIST__( ISsXmlArchiver* ar , std::vector<myclass*>& l
 }
 
 
-#define	SSAR_DECLARE_LIST(t)  __SSAR_DECLARE_LIST__( ar , t , #t)
-#define	SSAR_DECLARE_LIST2(t,s)  __SSAR_DECLARE_LIST__( ar , t , s)
-#define	SSAR_DECLARE_LISTEX(t,key)  __SSAR_DECLARE_LIST__( ar , t , #t , key )
+#define	SPRITESTUDIO6DSK_SSAR_DECLARE_LIST(t)  spritestudio6::__SSAR_DECLARE_LIST__( ar , t , #t)
+#define	SPRITESTUDIO6DSK_SSAR_DECLARE_LIST2(t,s)  spritestudio6::__SSAR_DECLARE_LIST__( ar , t , s)
+#define	SPRITESTUDIO6DSK_SSAR_DECLARE_LISTEX(t,key)  spritestudio6::__SSAR_DECLARE_LIST__( ar , t , #t , key )
 
 template<class myclass>
 inline bool	__SSAR_DECLARE_ENUM__( ISsXmlArchiver* ar ,myclass& type, const char* name  )
@@ -261,8 +268,8 @@ inline bool	__SSAR_DECLARE_ATTRIBUTE_ENUM__( ISsXmlArchiver* ar ,myclass& type, 
 
 
 
-#define SSAR_DECLARE_ENUM(t) __SSAR_DECLARE_ENUM__( ar , t , #t)
-#define SSAR_DECLARE_ATTRIBUTE_ENUM(t) __SSAR_DECLARE_ATTRIBUTE_ENUM__( ar , t , #t)
+#define SPRITESTUDIO6DSK_SSAR_DECLARE_ENUM(t) spritestudio6::__SSAR_DECLARE_ENUM__( ar , t , #t)
+#define SPRITESTUDIO6DSK_SSAR_DECLARE_ATTRIBUTE_ENUM(t) spritestudio6::__SSAR_DECLARE_ATTRIBUTE_ENUM__( ar , t , #t)
 
 
 bool	StringToPoint2( const std::string& str , SsPoint2& point );
@@ -274,7 +281,10 @@ bool	StringToTriangle(const std::string& str, SsTriangle& tri);
 void	SsArchiverInit();
 
 
-#define AR_SELF_CHECK() if ( this->getxml() == 0 ) return false;
+#define SPRITESTUDIO6DSK_AR_SELF_CHECK() if ( this->getxml() == 0 ) return false;
 
+
+
+}	// namespace spritestudio6
 
 #endif

--- a/Common/Loader/ssattribute.cpp
+++ b/Common/Loader/ssattribute.cpp
@@ -3,7 +3,8 @@
 #include "ssattribute.h"
 #include "../Helper/DebugPrint.h"
 
-
+namespace spritestudio6
+{
 
 
 const SsKeyframe*	SsAttribute::firstKey()
@@ -232,7 +233,7 @@ void	GetSsSignalAnime( const SsKeyframe* key , SsSignalAttr& v )
 			SsSignalParam param;
 			const SsValue& val2 = itr2->second;
 			SsSignalParamType::_enum type;
-			SsSignalParamValue value;
+//			SsSignalParamValue value;
 
 			param.paramId = val2["paramId"].get<SsString>();
 
@@ -379,3 +380,5 @@ void	GetSsDeformAnime(const SsKeyframe* key, SsDeformAttr& v)
 	}
 }
 
+
+}	// namespace spritestudio6

--- a/Common/Loader/ssattribute.h
+++ b/Common/Loader/ssattribute.h
@@ -8,7 +8,8 @@
 #include	<map>
 
 
-
+namespace spritestudio6
+{
 
 
 //アニメーション中のキーフレームの内容を表現するクラス
@@ -26,14 +27,14 @@ public:
 	  {}
 	virtual ~SsKeyframe(){}
 
-	SSSERIALIZE_BLOCK
+	SPRITESTUDIO6DSK_SERIALIZE_BLOCK
 	{
-		SSAR_DECLARE_ATTRIBUTE( time );
-		SSAR_DECLARE_ATTRIBUTE_ENUM( ipType );
+		SPRITESTUDIO6DSK_SSAR_DECLARE_ATTRIBUTE( time );
+		SPRITESTUDIO6DSK_SSAR_DECLARE_ATTRIBUTE_ENUM( ipType );
 
 		if ( SsNeedsCurveParams(ipType) )
 		{
-			SSAR_DECLARE( curve );
+			SPRITESTUDIO6DSK_SSAR_DECLARE( curve );
 		}
 		
 		SsValueSeriarizer( ar , value );
@@ -64,10 +65,10 @@ public:
 	}
 
 
-	SSSERIALIZE_BLOCK
+	SPRITESTUDIO6DSK_SERIALIZE_BLOCK
 	{
-		SSAR_DECLARE_ATTRIBUTE_ENUM( tag );
-		SSAR_DECLARE_LISTEX( key ,  "" );
+		SPRITESTUDIO6DSK_SSAR_DECLARE_ATTRIBUTE_ENUM( tag );
+		SPRITESTUDIO6DSK_SSAR_DECLARE_LISTEX( key ,  "" );
 
 		key_dic.clear();
 		for ( AttributeKeyList::iterator itr = key.begin() ; itr != key.end() ; itr++)
@@ -106,5 +107,7 @@ void	GetSsInstparamAnime( const SsKeyframe* key , SsInstanceAttr& v );
 void	GetSsEffectParamAnime( const SsKeyframe* key , SsEffectAttr& v );
 void	GetSsDeformAnime(const SsKeyframe* key, SsDeformAttr& v);
 
+
+}	// namespace spritestudio6
 
 #endif

--- a/Common/Loader/sscharconverter.cpp
+++ b/Common/Loader/sscharconverter.cpp
@@ -13,6 +13,9 @@
 
 #endif
 
+namespace spritestudio6
+{
+
 std::string SsCharConverter::utf8_to_sjis(const std::string &src) {
 #if __APPLE__ && TARGET_OS_MAC
     CFStringRef srcStr = CFStringCreateWithBytes(kCFAllocatorDefault, (const UInt8 *) src.c_str(), src.length(), kCFStringEncodingUTF8, FALSE);
@@ -36,7 +39,7 @@ std::string SsCharConverter::utf8_to_sjis(const std::string &src) {
 #elif _WIN32 || _WIN64
     auto const srcWCharSize = ::MultiByteToWideChar(CP_UTF8, 0U, src.data(), -1, nullptr, 0U);
     std::vector<wchar_t> srcWCharData(srcWCharSize, L'\0');
-    if (::MultiByteToWideChar(CP_UTF8, 0U, src.data(), -1, srcWCharData.data(), srcWCharData.size()) == 0) {
+    if (::MultiByteToWideChar(CP_UTF8, 0U, src.data(), -1, srcWCharData.data(), (int)(srcWCharData.size())) == 0) {
         throw std::system_error{ static_cast<int>(::GetLastError()), std::system_category() };
     }
     srcWCharData.resize(std::char_traits<wchar_t>::length(srcWCharData.data()));
@@ -45,7 +48,7 @@ std::string SsCharConverter::utf8_to_sjis(const std::string &src) {
     std::wstring srcWChar(srcWCharData.begin(), srcWCharData.end());
     auto const destSize = ::WideCharToMultiByte(CP_ACP, 0U, srcWChar.data(), -1, nullptr, 0, nullptr, nullptr);
     std::vector<char> dest(destSize, '\0');
-    if (::WideCharToMultiByte(CP_ACP, 0U, srcWChar.data(), -1, dest.data(), dest.size(), nullptr, nullptr) == 0) {
+    if (::WideCharToMultiByte(CP_ACP, 0U, srcWChar.data(), -1, dest.data(), (int)(dest.size()), nullptr, nullptr) == 0) {
         throw std::system_error{ static_cast<int>(::GetLastError()), std::system_category() };
     }
     dest.resize(std::char_traits<char>::length(dest.data()));
@@ -68,3 +71,4 @@ std::string SsCharConverter::convert_path_string(const std::string &str) {
     return dst;
 }
 
+}   // namespace spritestudio6

--- a/Common/Loader/sscharconverter.h
+++ b/Common/Loader/sscharconverter.h
@@ -3,10 +3,15 @@
 
 #include <string>
 
+namespace spritestudio6
+{
+
 class SsCharConverter {
 public:
 	static std::string utf8_to_sjis(const std::string &src);
 	static std::string convert_path_string(const std::string &str);
 };
+
+}	// namespace spritestudio6
 
 #endif //SSSDK_SSCHARCONVERTER_H

--- a/Common/Loader/ssloader.h
+++ b/Common/Loader/ssloader.h
@@ -127,9 +127,8 @@
 #include "ssInterpolation.h"
 
 //SDKを更新する場合はバージョン番号を変更してください
+// MEMO: 本マクロについては、SPRITESTUDIO6SDKに限らないラベルのため、SPRITESTUDIO6_の接頭にしていません。
 #define SPRITESTUDIOSDK_VERSION "SpriteStudio 6 SDK Version 1.7.4"
-
-
 
 
 #endif

--- a/Common/Loader/ssloader_ssae.cpp
+++ b/Common/Loader/ssloader_ssae.cpp
@@ -1,13 +1,16 @@
 ﻿#include "ssloader_ssae.h"
 
+namespace spritestudio6
+{
+
 
 SsAnimePack*	ssloader_ssae::Load(const std::string& filename )
 {
 
 	SsAnimePack* anime = new SsAnimePack();
 
-	XMLDocument xml;
-	if ( XML_SUCCESS == xml.LoadFile( filename.c_str() ) )
+	libXML::XMLDocument xml;
+	if ( libXML::XML_SUCCESS == xml.LoadFile( filename.c_str() ) )
 	{
 		SsXmlIArchiver ar( xml.GetDocument() , "SpriteStudioAnimePack" );
 		anime->__Serialize( &ar );
@@ -69,8 +72,8 @@ void	SsMeshBind::loader(ISsXmlArchiver* ar)
 void	SsMeshBindInfo::fromString(SsString str)
 {
 
-	memset(weight, 0, SSMESHPART_BONEMAX *  sizeof(float));
-	memset(boneIndex, 0 , SSMESHPART_BONEMAX * sizeof(int));
+	memset(weight, 0, SSMESHBIND_BONEMAX *  sizeof(float));
+	memset(boneIndex, 0 , SSMESHBIND_BONEMAX * sizeof(int));
 	bindBoneNum = 0;
 
 
@@ -92,3 +95,4 @@ void	SsMeshBindInfo::fromString(SsString str)
 }
 
 
+}	// namespace spritestudio6

--- a/Common/Loader/ssloader_ssae.h
+++ b/Common/Loader/ssloader_ssae.h
@@ -7,6 +7,9 @@
 
 #define SPRITESTUDIO6_SSAEVERSION "2.00.01"
 
+namespace spritestudio6
+{
+
 class SsAnimation;
 
 
@@ -30,19 +33,19 @@ public:
 public:
 
 	///シリアライズのための宣言です。
-	SSSERIALIZE_BLOCK
+	SPRITESTUDIO6DSK_SERIALIZE_BLOCK
 	{
-		SSAR_DECLARE( fps );
-		SSAR_DECLARE( frameCount );
-		SSAR_DECLARE( canvasSize );
-		SSAR_DECLARE( pivot );
-		SSAR_DECLARE_ENUM(sortMode);
+		SPRITESTUDIO6DSK_SSAR_DECLARE( fps );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( frameCount );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( canvasSize );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( pivot );
+		SPRITESTUDIO6DSK_SSAR_DECLARE_ENUM(sortMode);
 		//タグが存在しない（Ver5.8以前のデータ）場合は初期値を入れる
-		if (SSAR_DECLARE(startFrame) == false)
+		if (SPRITESTUDIO6DSK_SSAR_DECLARE(startFrame) == false)
 		{
 			startFrame = 0;
 		}
-		if (SSAR_DECLARE(endFrame) == false)
+		if (SPRITESTUDIO6DSK_SSAR_DECLARE(endFrame) == false)
 		{
 			endFrame = frameCount - 1;
 		}
@@ -141,43 +144,43 @@ public:
 
 
 	///シリアライズのための宣言です。
-	SSSERIALIZE_BLOCK
+	SPRITESTUDIO6DSK_SERIALIZE_BLOCK
 	{
-		SSAR_DECLARE( name );
-		SSAR_DECLARE( arrayIndex );
-		SSAR_DECLARE( parentIndex );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( name );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( arrayIndex );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( parentIndex );
 
-		SSAR_DECLARE_ENUM( type );
-		SSAR_DECLARE_ENUM( boundsType );
-		SSAR_DECLARE_ENUM( inheritType );
-		SSAR_DECLARE_ENUM( alphaBlendType );
-		SSAR_DECLARE( show );
-		SSAR_DECLARE( locked );
-		SSAR_DECLARE( colorLabel );
-		SSAR_DECLARE( maskInfluence );
+		SPRITESTUDIO6DSK_SSAR_DECLARE_ENUM( type );
+		SPRITESTUDIO6DSK_SSAR_DECLARE_ENUM( boundsType );
+		SPRITESTUDIO6DSK_SSAR_DECLARE_ENUM( inheritType );
+		SPRITESTUDIO6DSK_SSAR_DECLARE_ENUM( alphaBlendType );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( show );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( locked );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( colorLabel );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( maskInfluence );
 
-		SSAR_DECLARE( refAnimePack );
-		SSAR_DECLARE( refAnime );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( refAnimePack );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( refAnime );
 
-		SSAR_DECLARE( refEffectName );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( refEffectName );
 
-		SSAR_DECLARE( boneLength );
-		SSAR_DECLARE( bonePosition );
-		SSAR_DECLARE( boneRotation );
-		SSAR_DECLARE( weightPosition );
-		SSAR_DECLARE( weightImpact );
-		SSAR_DECLARE( meshWeightType );
-		SSAR_DECLARE( meshWeightStrong );
-		SSAR_DECLARE( IKDepth );
-		SSAR_DECLARE_ENUM( IKRotationArrow );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( boneLength );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( bonePosition );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( boneRotation );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( weightPosition );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( weightImpact );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( meshWeightType );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( meshWeightStrong );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( IKDepth );
+		SPRITESTUDIO6DSK_SSAR_DECLARE_ENUM( IKRotationArrow );
 
 		//継承率後に改良を実施
 		if ( ar->getType() == EnumSsArchiver::in )
 		{
-			XMLElement* e = ar->getxml()->FirstChildElement( "ineheritRates" );
+			libXML::XMLElement* e = ar->getxml()->FirstChildElement( "ineheritRates" );
 			if ( e )
 			{
-				XMLElement* ec = e->FirstChildElement();
+				libXML::XMLElement* ec = e->FirstChildElement();
 				while(ec)
 				{
 					//継承設定の取得
@@ -193,20 +196,23 @@ public:
 	}
 };
 
-#define SSMESHPART_BONEMAX	(128)
-
+enum 
+{
+	// MEMO: ssplayer_mesh.hにSSMESHPART_BONEMAXがあるので統合を考えること。
+	SSMESHBIND_BONEMAX = 128,
+};
 class SsMeshBindInfo
 {
 public:
-	int			weight[SSMESHPART_BONEMAX];
-	SsString	boneName[SSMESHPART_BONEMAX];
-	int			boneIndex[SSMESHPART_BONEMAX];
-	SsVector3   offset[SSMESHPART_BONEMAX];
+	int			weight[SSMESHBIND_BONEMAX];
+	SsString	boneName[SSMESHBIND_BONEMAX];
+	int			boneIndex[SSMESHBIND_BONEMAX];
+	SsVector3   offset[SSMESHBIND_BONEMAX];
 	int			bindBoneNum;
 
 	SsMeshBindInfo()
 	{
-		for (int i = 0; i < SSMESHPART_BONEMAX; i++)
+		for (int i = 0; i < SSMESHBIND_BONEMAX; i++)
 		{
 			weight[i] = 0;
 			boneName[i] = "";
@@ -238,7 +244,7 @@ public:
 
 	void	loader(ISsXmlArchiver* ar);
 
-	SSSERIALIZE_BLOCK
+	SPRITESTUDIO6DSK_SERIALIZE_BLOCK
 	{
 		loader(ar);
 	}
@@ -267,13 +273,13 @@ public:
 	}
 
 	///シリアライズのための宣言です。
-	SSSERIALIZE_BLOCK
+	SPRITESTUDIO6DSK_SERIALIZE_BLOCK
 	{
 		std::vector<SsString> tempMeshList;
 
-		SSAR_DECLARE_LIST( partList );
-		SSAR_DECLARE( boneList );
-		SSAR_DECLARE_LIST( meshList );
+		SPRITESTUDIO6DSK_SSAR_DECLARE_LIST( partList );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( boneList );
+		SPRITESTUDIO6DSK_SSAR_DECLARE_LIST( meshList );
 		setupAnimation = NULL;
 	}
 };
@@ -295,10 +301,10 @@ public:
 	}
 
 	///シリアライズのための宣言です。
-	SSSERIALIZE_BLOCK
+	SPRITESTUDIO6DSK_SERIALIZE_BLOCK
 	{
-		SSAR_DECLARE( partName );
-		SSAR_DECLARE_LISTEX( attributes , "attribute" );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( partName );
+		SPRITESTUDIO6DSK_SSAR_DECLARE_LISTEX( attributes , "attribute" );
 	}
 };
 
@@ -310,10 +316,10 @@ public:
 	SsString	name;	///< 名前 [変数名変更禁止]
 	int			time;	///< 設置された時間(フレーム) [変数名変更禁止]
 
-	SSSERIALIZE_BLOCK
+	SPRITESTUDIO6DSK_SERIALIZE_BLOCK
 	{
-		SSAR_DECLARE( name );
-		SSAR_DECLARE( time );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( name );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( time );
 	}
 
 private:
@@ -342,13 +348,13 @@ public:
 	}
 
 	///シリアライズのための宣言です。
-	SSSERIALIZE_BLOCK
+	SPRITESTUDIO6DSK_SERIALIZE_BLOCK
 	{
-		SSAR_DECLARE( name );
-		SSAR_STRUCT_DECLARE( settings );
-		SSAR_DECLARE_LISTEX( labels , "value" );
-		SSAR_DECLARE_LISTEX( partAnimes , "partAnime" );
-		SSAR_DECLARE(isSetup);
+		SPRITESTUDIO6DSK_SSAR_DECLARE( name );
+		SPRITESTUDIO6DSK_SSAR_STRUCT_DECLARE( settings );
+		SPRITESTUDIO6DSK_SSAR_DECLARE_LISTEX( labels , "value" );
+		SPRITESTUDIO6DSK_SSAR_DECLARE_LISTEX( partAnimes , "partAnime" );
+		SPRITESTUDIO6DSK_SSAR_DECLARE(isSetup);
 	}
 };
 
@@ -375,14 +381,14 @@ public:
 	}
 
 	///シリアライズのための宣言です。
-	SSSERIALIZE_BLOCK
+	SPRITESTUDIO6DSK_SERIALIZE_BLOCK
 	{
-		SSAR_DECLARE_ATTRIBUTE(version);
-		SSAR_STRUCT_DECLARE( settings );
-		SSAR_DECLARE( name );
-		SSAR_STRUCT_DECLARE( Model );
-		SSAR_DECLARE( cellmapNames );
-		SSAR_DECLARE_LISTEX( animeList , "anime" );
+		SPRITESTUDIO6DSK_SSAR_DECLARE_ATTRIBUTE(version);
+		SPRITESTUDIO6DSK_SSAR_STRUCT_DECLARE( settings );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( name );
+		SPRITESTUDIO6DSK_SSAR_STRUCT_DECLARE( Model );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( cellmapNames );
+		SPRITESTUDIO6DSK_SSAR_DECLARE_LISTEX( animeList , "anime" );
 
 		//モデルにセットアップアニメーションを設定する
 		int i;
@@ -423,6 +429,7 @@ public:
 
 
 
+}	// namespace spritestudio6
 
 
 #endif

--- a/Common/Loader/ssloader_ssce.cpp
+++ b/Common/Loader/ssloader_ssce.cpp
@@ -2,6 +2,8 @@
 #include "ssstring_uty.h"
 
 
+namespace spritestudio6
+{
 
 SsCellMap*	ssloader_ssce::Load(const std::string& filename )
 {
@@ -10,8 +12,8 @@ SsCellMap*	ssloader_ssce::Load(const std::string& filename )
 	
 	SsCellMap* cellmap = new SsCellMap();
 
-	XMLDocument xml;
-	if ( XML_SUCCESS == xml.LoadFile( filename.c_str() ) )
+	libXML::XMLDocument xml;
+	if ( libXML::XML_SUCCESS == xml.LoadFile( filename.c_str() ) )
 	{
 		SsXmlIArchiver ar( xml.GetDocument() , "SpriteStudioCellMap" );
 		cellmap->__Serialize( &ar );
@@ -26,3 +28,5 @@ SsCellMap*	ssloader_ssce::Load(const std::string& filename )
 
 
 
+
+}	// namespace spritestudio6

--- a/Common/Loader/ssloader_ssce.h
+++ b/Common/Loader/ssloader_ssce.h
@@ -6,6 +6,9 @@
 
 #define SPRITESTUDIO6_SSCEVERSION "2.00.00"
 
+namespace spritestudio6
+{
+
 ///パーツに使用される画素の矩形範囲を示した構造です。
 class SsCell 
 {
@@ -50,23 +53,23 @@ public:
 
 
 	///シリアライズのための宣言です。
-	SSSERIALIZE_BLOCK
+	SPRITESTUDIO6DSK_SERIALIZE_BLOCK
 	{
-		SSAR_DECLARE( name );
-		SSAR_DECLARE( pos );
-		SSAR_DECLARE( size );
-		SSAR_DECLARE( pivot );
-		SSAR_DECLARE( rotated );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( name );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( pos );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( size );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( pivot );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( rotated );
 
-		SSAR_DECLARE(ismesh);
+		SPRITESTUDIO6DSK_SSAR_DECLARE(ismesh);
 		//SsVerctor2のリストのシリアライズが必要
-		SSAR_DECLARE(innerPoint );
-		SSAR_DECLARE(outerPoint);
-		SSAR_DECLARE(meshPointList);
-		SSAR_DECLARE(meshTriList);
-		SSAR_DECLARE_ENUM(divtype);
-		SSAR_DECLARE(divw);
-		SSAR_DECLARE(divh);
+		SPRITESTUDIO6DSK_SSAR_DECLARE(innerPoint );
+		SPRITESTUDIO6DSK_SSAR_DECLARE(outerPoint);
+		SPRITESTUDIO6DSK_SSAR_DECLARE(meshPointList);
+		SPRITESTUDIO6DSK_SSAR_DECLARE(meshTriList);
+		SPRITESTUDIO6DSK_SSAR_DECLARE_ENUM(divtype);
+		SPRITESTUDIO6DSK_SSAR_DECLARE(divw);
+		SPRITESTUDIO6DSK_SSAR_DECLARE(divh);
 	}
 };
 
@@ -107,17 +110,17 @@ public:
 	}
 
 	///シリアライズのための宣言です。
-	SSSERIALIZE_BLOCK
+	SPRITESTUDIO6DSK_SERIALIZE_BLOCK
 	{
-		SSAR_DECLARE_ATTRIBUTE(version);
-		SSAR_DECLARE( name );
-		SSAR_DECLARE( imagePath );
-		SSAR_DECLARE( pixelSize );
-		SSAR_DECLARE( overrideTexSettings );
-		SSAR_DECLARE_ENUM( wrapMode );
-		SSAR_DECLARE_ENUM( filterMode );
+		SPRITESTUDIO6DSK_SSAR_DECLARE_ATTRIBUTE(version);
+		SPRITESTUDIO6DSK_SSAR_DECLARE( name );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( imagePath );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( pixelSize );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( overrideTexSettings );
+		SPRITESTUDIO6DSK_SSAR_DECLARE_ENUM( wrapMode );
+		SPRITESTUDIO6DSK_SSAR_DECLARE_ENUM( filterMode );
 
-		SSAR_DECLARE_LISTEX( cells ,"cell" );
+		SPRITESTUDIO6DSK_SSAR_DECLARE_LISTEX( cells ,"cell" );
 	}
 };
 
@@ -133,5 +136,6 @@ public:
 
 };
 
+}	// namespace spritestudio6
 
 #endif

--- a/Common/Loader/ssloader_ssee.cpp
+++ b/Common/Loader/ssloader_ssee.cpp
@@ -6,6 +6,10 @@
 
 #include "../Helper/DebugPrint.h"
 
+namespace spritestudio6
+{
+
+
 SsEffectFile*	ssloader_ssee::Load(const std::string& filename )
 {
 
@@ -14,8 +18,8 @@ SsEffectFile*	ssloader_ssee::Load(const std::string& filename )
 	
 	SsEffectFile* effectFile = new SsEffectFile();
 
-	XMLDocument xml;
-	if ( XML_SUCCESS == xml.LoadFile( filename.c_str() ) )
+	libXML::XMLDocument xml;
+	if ( libXML::XML_SUCCESS == xml.LoadFile( filename.c_str() ) )
 	{
 		SsXmlIArchiver ar( xml.GetDocument() , "SpriteStudioEffect" );
 		effectFile->__Serialize( &ar );
@@ -59,3 +63,5 @@ void	ssloader_ssee::loadPostProcessing( SsEffectFile* file , SsProject* pj )
 
 
 }
+
+}	// namespace spritestudio6

--- a/Common/Loader/ssloader_ssee.h
+++ b/Common/Loader/ssloader_ssee.h
@@ -8,6 +8,8 @@
 
 #define SPRITESTUDIO6_SSEEVERSION "2.00.00"
 
+namespace spritestudio6
+{
 
 class SimpleTree
 {
@@ -93,13 +95,13 @@ public:
 	{}
 	~SsEffectNode(){}
 
-	SSSERIALIZE_BLOCK
+	SPRITESTUDIO6DSK_SERIALIZE_BLOCK
 	{
-		SSAR_DECLARE(arrayIndex);
-		SSAR_DECLARE(parentIndex);		
-		SSAR_DECLARE_ENUM(type);	
-		SSAR_DECLARE(visible);	
-		SSAR_STRUCT_DECLARE(behavior);	
+		SPRITESTUDIO6DSK_SSAR_DECLARE(arrayIndex);
+		SPRITESTUDIO6DSK_SSAR_DECLARE(parentIndex);		
+		SPRITESTUDIO6DSK_SSAR_DECLARE_ENUM(type);	
+		SPRITESTUDIO6DSK_SSAR_DECLARE(visible);	
+		SPRITESTUDIO6DSK_SSAR_STRUCT_DECLARE(behavior);	
 	}
 
 
@@ -143,19 +145,19 @@ public:
 
 
 	//シリアライザ
-	SSSERIALIZE_BLOCK
+	SPRITESTUDIO6DSK_SERIALIZE_BLOCK
 	{
-		SSAR_DECLARE(lockRandSeed);
-		SSAR_DECLARE(isLockRandSeed);
-		SSAR_DECLARE(fps);
-		SSAR_DECLARE(bgcolor);
-		SSAR_DECLARE(layoutScaleX);
+		SPRITESTUDIO6DSK_SSAR_DECLARE(lockRandSeed);
+		SPRITESTUDIO6DSK_SSAR_DECLARE(isLockRandSeed);
+		SPRITESTUDIO6DSK_SSAR_DECLARE(fps);
+		SPRITESTUDIO6DSK_SSAR_DECLARE(bgcolor);
+		SPRITESTUDIO6DSK_SSAR_DECLARE(layoutScaleX);
 		if ( layoutScaleX == 0 ) layoutScaleX = 100;
 
-		SSAR_DECLARE(layoutScaleY);
+		SPRITESTUDIO6DSK_SSAR_DECLARE(layoutScaleY);
 		if ( layoutScaleY == 0 ) layoutScaleY = 100;
 
-		SSAR_DECLARE_LISTEX(nodeList,"node");
+		SPRITESTUDIO6DSK_SSAR_DECLARE_LISTEX(nodeList,"node");
 
 		//ツリーの構築
 		if ( nodeList.size() > 0 )
@@ -194,11 +196,11 @@ public:
 	SsEffectFile(){}
 	virtual ~SsEffectFile(){}
 
-	SSSERIALIZE_BLOCK
+	SPRITESTUDIO6DSK_SERIALIZE_BLOCK
 	{
-		SSAR_DECLARE_ATTRIBUTE(version);
-		SSAR_DECLARE(name);
-		SSAR_STRUCT_DECLARE( effectData );
+		SPRITESTUDIO6DSK_SSAR_DECLARE_ATTRIBUTE(version);
+		SPRITESTUDIO6DSK_SSAR_DECLARE(name);
+		SPRITESTUDIO6DSK_SSAR_STRUCT_DECLARE( effectData );
 		effectData.effectName = name;
 	}
 
@@ -220,5 +222,6 @@ public:
 
 
 
+}	// namespace spritestudio6
 
 #endif

--- a/Common/Loader/ssloader_sspj.cpp
+++ b/Common/Loader/ssloader_sspj.cpp
@@ -8,7 +8,6 @@
 #include "../Helper/DebugPrint.h"
 #include "sscharconverter.h"
 
-
 namespace spritestudio6
 {
 
@@ -128,7 +127,6 @@ SsSequence*		SsProject::findSequence( SsString& sequencePackName , SsString& Seq
 
 SsProject*	ssloader_sspj::Load(const std::string& filename )
 {
-
 	libXML::XMLDocument xml;
 	if ( libXML::XML_SUCCESS == xml.LoadFile( filename.c_str() ) )
 	{
@@ -200,6 +198,7 @@ SsProject*	ssloader_sspj::Load(const std::string& filename )
 			proj->textureList.push_back(i->first);
 		}
 
+		//エフェクトリストを元に読み込みます。
 		for ( size_t i = 0 ;i < proj->getEffectFileNum() ; i++ )
 		{
 			SsString sscepath = SsCharConverter::convert_path_string(proj->getEffectFilePath(i));
@@ -241,6 +240,7 @@ SsProject*	ssloader_sspj::Load(const std::string& filename )
 				return 0;
 			}
 		}
+
 		return proj;
 	}	
 

--- a/Common/Loader/ssloader_sspj.cpp
+++ b/Common/Loader/ssloader_sspj.cpp
@@ -9,6 +9,9 @@
 #include "sscharconverter.h"
 
 
+namespace spritestudio6
+{
+
 
 SsString	SsProject::getSsceBasepath(){ 
 	return getFullPath( m_proj_filepath , settings.cellMapBaseDirectory );
@@ -126,8 +129,8 @@ SsSequence*		SsProject::findSequence( SsString& sequencePackName , SsString& Seq
 SsProject*	ssloader_sspj::Load(const std::string& filename )
 {
 
-	XMLDocument xml;
-	if ( XML_SUCCESS == xml.LoadFile( filename.c_str() ) )
+	libXML::XMLDocument xml;
+	if ( libXML::XML_SUCCESS == xml.LoadFile( filename.c_str() ) )
 	{
 		SsXmlIArchiver ar( xml.GetDocument() , "SpriteStudioProject" );
 
@@ -268,3 +271,6 @@ SsCellMap* SsProject::getCellMap( int index )
 {
 	return cellmapList[index];
 }
+
+
+}	// namespace spritestudio6

--- a/Common/Loader/ssloader_sspj.h
+++ b/Common/Loader/ssloader_sspj.h
@@ -9,6 +9,9 @@
 
 #define SPRITESTUDIO6_SSPJVERSION "2.00.00"
 
+namespace spritestudio6
+{
+
 /// プロジェクトファイルの設定が記載されているデータです。
 /// 以下のタグはエディタ編集用のデータなので読み飛ばします。
 //	編集時設定のためよまない
@@ -48,18 +51,18 @@ public:
 	}
 	
 	///シリアライズのための宣言です。
-	SSSERIALIZE_BLOCK
+	SPRITESTUDIO6DSK_SERIALIZE_BLOCK
 	{
-		SSAR_DECLARE(animeBaseDirectory);
-		SSAR_DECLARE(cellMapBaseDirectory);
-		SSAR_DECLARE(imageBaseDirectory);
-		SSAR_DECLARE(effectBaseDirectory);
+		SPRITESTUDIO6DSK_SSAR_DECLARE(animeBaseDirectory);
+		SPRITESTUDIO6DSK_SSAR_DECLARE(cellMapBaseDirectory);
+		SPRITESTUDIO6DSK_SSAR_DECLARE(imageBaseDirectory);
+		SPRITESTUDIO6DSK_SSAR_DECLARE(effectBaseDirectory);
 
-		SSAR_DECLARE(exportBaseDirectory);
-		SSAR_DECLARE(queryExportBaseDirectory);
-		SSAR_DECLARE_ENUM( wrapMode );
-		SSAR_DECLARE_ENUM( filterMode );
-		SSAR_DECLARE_ENUM(vertexAnimeFloat);
+		SPRITESTUDIO6DSK_SSAR_DECLARE(exportBaseDirectory);
+		SPRITESTUDIO6DSK_SSAR_DECLARE(queryExportBaseDirectory);
+		SPRITESTUDIO6DSK_SSAR_DECLARE_ENUM( wrapMode );
+		SPRITESTUDIO6DSK_SSAR_DECLARE_ENUM( filterMode );
+		SPRITESTUDIO6DSK_SSAR_DECLARE_ENUM(vertexAnimeFloat);
 
 	}
 };
@@ -167,14 +170,14 @@ public:
 
 
 	///シリアライズのための宣言です。
-	SSSERIALIZE_BLOCK
+	SPRITESTUDIO6DSK_SERIALIZE_BLOCK
 	{
-		SSAR_DECLARE_ATTRIBUTE(version);
-		SSAR_STRUCT_DECLARE( settings );
-		SSAR_DECLARE( cellmapNames );
-		SSAR_DECLARE( animepackNames );
-		SSAR_DECLARE( effectFileNames );
-		SSAR_DECLARE( sequencepackNames );
+		SPRITESTUDIO6DSK_SSAR_DECLARE_ATTRIBUTE(version);
+		SPRITESTUDIO6DSK_SSAR_STRUCT_DECLARE( settings );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( cellmapNames );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( animepackNames );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( effectFileNames );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( sequencepackNames );
 
 	}
 
@@ -255,5 +258,6 @@ public:
 };
 
 
+}	// namespace spritestudio6
 
 #endif

--- a/Common/Loader/ssloader_ssqe.cpp
+++ b/Common/Loader/ssloader_ssqe.cpp
@@ -1,13 +1,16 @@
 ﻿#include "ssloader_ssqe.h"
 
+namespace spritestudio6
+{
+
 
 SsSequencePack*	ssloader_ssqe::Load(const std::string& filename )
 {
 
 	SsSequencePack* sequence = new SsSequencePack();
 
-	XMLDocument xml;
-	if ( XML_SUCCESS == xml.LoadFile( filename.c_str() ) )
+	libXML::XMLDocument xml;
+	if ( libXML::XML_SUCCESS == xml.LoadFile( filename.c_str() ) )
 	{
 		SsXmlIArchiver ar( xml.GetDocument() , "SpriteStudioSequencePack" );
 		sequence->__Serialize( &ar );
@@ -33,3 +36,5 @@ SsSequence*	SsSequencePack::findSequence(SsString& name)
 	}
 	return 0;
 }
+
+}	// namespace spritestudio6

--- a/Common/Loader/ssloader_ssqe.h
+++ b/Common/Loader/ssloader_ssqe.h
@@ -6,6 +6,9 @@
 
 #define SPRITESTUDIO6_SSQEVERSION "1.00.00"
 
+namespace spritestudio6
+{
+
 class SsSequence;
 
 
@@ -26,11 +29,11 @@ public:
 	}
 
 	///シリアライズのための宣言です。
-	SSSERIALIZE_BLOCK
+	SPRITESTUDIO6DSK_SERIALIZE_BLOCK
 	{
-		SSAR_DECLARE( refAnimePack );
-		SSAR_DECLARE( refAnime );
-		SSAR_DECLARE( repeatCount );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( refAnimePack );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( refAnime );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( repeatCount );
 	}
 };
 
@@ -51,12 +54,12 @@ public:
 	}
 
 	///シリアライズのための宣言です。
-	SSSERIALIZE_BLOCK
+	SPRITESTUDIO6DSK_SERIALIZE_BLOCK
 	{
-		SSAR_DECLARE( name );
-		SSAR_DECLARE( index );
-		SSAR_DECLARE_ENUM( type );
-		SSAR_DECLARE_LISTEX( list , "value" );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( name );
+		SPRITESTUDIO6DSK_SSAR_DECLARE( index );
+		SPRITESTUDIO6DSK_SSAR_DECLARE_ENUM( type );
+		SPRITESTUDIO6DSK_SSAR_DECLARE_LISTEX( list , "value" );
 	}
 };
 
@@ -80,11 +83,11 @@ public:
 	}
 
 	///シリアライズのための宣言です。
-	SSSERIALIZE_BLOCK
+	SPRITESTUDIO6DSK_SERIALIZE_BLOCK
 	{
-		SSAR_DECLARE_ATTRIBUTE(version);
-		SSAR_DECLARE( name );
-		SSAR_DECLARE_LISTEX( sequenceList , "sequence" );
+		SPRITESTUDIO6DSK_SSAR_DECLARE_ATTRIBUTE(version);
+		SPRITESTUDIO6DSK_SSAR_DECLARE( name );
+		SPRITESTUDIO6DSK_SSAR_DECLARE_LISTEX( sequenceList , "sequence" );
 
 
 	}
@@ -113,5 +116,6 @@ public:
 
 
 
+}	// namespace spritestudio6
 
 #endif

--- a/Common/Loader/ssstring_uty.cpp
+++ b/Common/Loader/ssstring_uty.cpp
@@ -44,15 +44,13 @@ void	split_string( const std::string &in_str ,
 
 
 std::string path2dir(const std::string &path) {
-//	const std::string::size_type pos = std::max<signed>(path.find_last_of('/'), path.find_last_of('\\'));
-	const std::string::size_type pos = std::max<size_t>(path.find_last_of('/'), path.find_last_of('\\'));
+	const std::string::size_type pos = std::max<signed>((signed)path.find_last_of('/'), (signed)path.find_last_of('\\'));
 	return (pos == std::string::npos) ? std::string()
 		: path.substr(0, pos + 1);
 }
 
 std::string path2file(const std::string &path) {
-//	return path.substr(std::max<signed>(path.find_last_of('/'), path.find_last_of('\\')) + 1);
-	return path.substr(std::max<size_t>(path.find_last_of('/'), path.find_last_of('\\')) + 1);
+	return path.substr((size_t)(std::max<signed>((signed)path.find_last_of('/'), (signed)path.find_last_of('\\')) + 1));
 }
 
 
@@ -87,8 +85,13 @@ std::string getFullPath( const std::string& basePath , const std::string &relPat
 #ifdef _WIN32
 	static char	curPath[_MAX_PATH];
 
+#if 0	// MEMO: エンバグしていると困るので、一応まだ残しておく
 	_chdir( basePath.c_str() );
 	_getcwd( curPath , _MAX_PATH ); 
+#else
+	_getcwd( curPath , _MAX_PATH ); 
+	_chdir( basePath.c_str() );
+#endif
 
 	static char	buffer_[_MAX_PATH];
 	_fullpath( buffer_ , relPath.c_str() , _MAX_PATH );

--- a/Common/Loader/ssstring_uty.cpp
+++ b/Common/Loader/ssstring_uty.cpp
@@ -10,6 +10,9 @@
 
 #endif
 
+namespace spritestudio6
+{
+
 
 //=========================================================================================
 //! 文字列の切り分け
@@ -41,13 +44,15 @@ void	split_string( const std::string &in_str ,
 
 
 std::string path2dir(const std::string &path) {
-	const std::string::size_type pos = std::max<signed>(path.find_last_of('/'), path.find_last_of('\\'));
+//	const std::string::size_type pos = std::max<signed>(path.find_last_of('/'), path.find_last_of('\\'));
+	const std::string::size_type pos = std::max<size_t>(path.find_last_of('/'), path.find_last_of('\\'));
 	return (pos == std::string::npos) ? std::string()
 		: path.substr(0, pos + 1);
 }
 
 std::string path2file(const std::string &path) {
-	return path.substr(std::max<signed>(path.find_last_of('/'), path.find_last_of('\\')) + 1);
+//	return path.substr(std::max<signed>(path.find_last_of('/'), path.find_last_of('\\')) + 1);
+	return path.substr(std::max<size_t>(path.find_last_of('/'), path.find_last_of('\\')) + 1);
 }
 
 
@@ -163,3 +168,6 @@ bool checkFileVersion(std::string fileVersion, std::string nowVersion)
 
 	return ret;
 }
+
+
+}	// namespace spritestudio6

--- a/Common/Loader/ssstring_uty.h
+++ b/Common/Loader/ssstring_uty.h
@@ -10,6 +10,9 @@
 #include <fstream>
 #include <iterator>
 
+namespace spritestudio6
+{
+
 /*
  * @brief     文字列を指定のkeyで分割して返します。
  *
@@ -118,5 +121,6 @@ public:
 
 };
 
+}	// namespace spritestudio6
 
 #endif

--- a/Common/Loader/sstypes.cpp
+++ b/Common/Loader/sstypes.cpp
@@ -1,5 +1,7 @@
-﻿
-#include "sstypes.h"
+﻿#include "sstypes.h"
+
+namespace spritestudio6
+{
 
 //---------------------------------------------------------------
 //相互変換 SsPartType
@@ -337,7 +339,7 @@ void	__StringToEnum_( SsString n , SsAttributeKind::_enum &out )
 }
 
 
-SS_DECLARE_ENUM_STRING_DEF( SsEffectNodeType );
+SPRITESTUDIO6DSK_DECLARE_ENUM_STRING_DEF( SsEffectNodeType );
 
 //---------------------------------------------------------------
 //相互変換 SsPartType
@@ -361,7 +363,7 @@ void 	__StringToEnum_( SsString n , SsEffectNodeType::_enum& out)
 }
 
 
-SS_DECLARE_ENUM_STRING_DEF( SsRenderBlendType );
+SPRITESTUDIO6DSK_DECLARE_ENUM_STRING_DEF( SsRenderBlendType );
 
 //---------------------------------------------------------------
 //相互変換 SsPartType
@@ -456,3 +458,6 @@ void 	__StringToEnum_(SsString n, SsSignalParamType::_enum& out)
 	if (n == "integer") out = SsSignalParamType::integer;
 	if (n == "floating") out = SsSignalParamType::floating;
 }
+
+
+}	// namespace spritestudio6

--- a/Common/Loader/sstypes.h
+++ b/Common/Loader/sstypes.h
@@ -10,12 +10,13 @@
 //===============================================================
 //Macros 
 //===============================================================
-#define	SS_DECLARE_ENUM_STRING_DEF(type) \
+#define	SPRITESTUDIO6DSK_DECLARE_ENUM_STRING_DEF(type) \
 	SsString	__EnumToString_( type::_enum n );\
 	void	__StringToEnum_( SsString n , type::_enum& out);\
 
 
-
+namespace spritestudio6
+{
 
 //===============================================================
 // Declare Type
@@ -378,7 +379,7 @@ namespace SsPartsSortMode
 		num
 	};
 };
-SS_DECLARE_ENUM_STRING_DEF( SsPartsSortMode );
+SPRITESTUDIO6DSK_DECLARE_ENUM_STRING_DEF( SsPartsSortMode );
 
 //---------------------------------------------------------------
 /// Animation Part Type
@@ -403,7 +404,7 @@ namespace SsPartType
 		num
 	};
 };
-SS_DECLARE_ENUM_STRING_DEF( SsPartType );
+SPRITESTUDIO6DSK_DECLARE_ENUM_STRING_DEF( SsPartType );
 
 
 //---------------------------------------------------------------
@@ -422,7 +423,7 @@ namespace SsBoundsType
 		num
 	};
 };
-SS_DECLARE_ENUM_STRING_DEF( SsBoundsType );
+SPRITESTUDIO6DSK_DECLARE_ENUM_STRING_DEF( SsBoundsType );
 
 
 //---------------------------------------------------------------
@@ -437,7 +438,7 @@ namespace SsInheritType
 		num
 	};
 };
-SS_DECLARE_ENUM_STRING_DEF( SsInheritType );
+SPRITESTUDIO6DSK_DECLARE_ENUM_STRING_DEF( SsInheritType );
 
 //---------------------------------------------------------------
 /// ブレンドタイプ
@@ -456,7 +457,7 @@ namespace SsBlendType
 		num
 	};
 };
-SS_DECLARE_ENUM_STRING_DEF( SsBlendType );
+SPRITESTUDIO6DSK_DECLARE_ENUM_STRING_DEF( SsBlendType );
 
 
 ///カラーブレンドキーが使用されている際のカラー適用範囲の定義
@@ -469,7 +470,7 @@ namespace SsColorBlendTarget
 		num
 	};
 };
-SS_DECLARE_ENUM_STRING_DEF( SsColorBlendTarget );
+SPRITESTUDIO6DSK_DECLARE_ENUM_STRING_DEF( SsColorBlendTarget );
 
 
 
@@ -488,7 +489,7 @@ namespace SsInterpolationType
 		num,
 	};
 };
-SS_DECLARE_ENUM_STRING_DEF( SsInterpolationType );
+SPRITESTUDIO6DSK_DECLARE_ENUM_STRING_DEF( SsInterpolationType );
 
 
 /// テクスチャラップモード
@@ -504,7 +505,7 @@ namespace SsTexWrapMode
 	};
 };
 
-SS_DECLARE_ENUM_STRING_DEF(SsTexWrapMode);
+SPRITESTUDIO6DSK_DECLARE_ENUM_STRING_DEF(SsTexWrapMode);
 
 /// テクスチャフィルターモード 画素補間方法
 namespace SsTexFilterMode
@@ -517,7 +518,7 @@ namespace SsTexFilterMode
 		num
 	};
 };
-SS_DECLARE_ENUM_STRING_DEF(SsTexFilterMode);
+SPRITESTUDIO6DSK_DECLARE_ENUM_STRING_DEF(SsTexFilterMode);
 
 
 
@@ -574,7 +575,7 @@ namespace SsAttributeKind
 };
 
 
-SS_DECLARE_ENUM_STRING_DEF(SsAttributeKind);
+SPRITESTUDIO6DSK_DECLARE_ENUM_STRING_DEF(SsAttributeKind);
 
 namespace SsKeyValueType
 {
@@ -686,7 +687,7 @@ namespace SsEffectNodeType
 		num
 	};
 };
-SS_DECLARE_ENUM_STRING_DEF( SsEffectNodeType );
+SPRITESTUDIO6DSK_DECLARE_ENUM_STRING_DEF( SsEffectNodeType );
 
 
 
@@ -701,7 +702,7 @@ namespace SsRenderBlendType
 		num
 	};
 };
-SS_DECLARE_ENUM_STRING_DEF( SsRenderBlendType );
+SPRITESTUDIO6DSK_DECLARE_ENUM_STRING_DEF( SsRenderBlendType );
 
 
 //2.0.1で追加　IKの方向
@@ -717,7 +718,7 @@ namespace SsIkRotationArrow
 	};
 };
 
-SS_DECLARE_ENUM_STRING_DEF(SsIkRotationArrow);
+SPRITESTUDIO6DSK_DECLARE_ENUM_STRING_DEF(SsIkRotationArrow);
 
 /// シーケンスタイプ
 namespace SsSequenceType
@@ -731,7 +732,7 @@ namespace SsSequenceType
 		num,
 	};
 };
-SS_DECLARE_ENUM_STRING_DEF( SsSequenceType );
+SPRITESTUDIO6DSK_DECLARE_ENUM_STRING_DEF( SsSequenceType );
 
 namespace SsSignalParamType
 {
@@ -744,7 +745,7 @@ namespace SsSignalParamType
 		num
 	};
 };
-SS_DECLARE_ENUM_STRING_DEF( SsSignalParamType );
+SPRITESTUDIO6DSK_DECLARE_ENUM_STRING_DEF( SsSignalParamType );
 
 
 class SsEffectAttr
@@ -923,7 +924,7 @@ namespace SsMeshDivType
 		num
 	};
 };
-SS_DECLARE_ENUM_STRING_DEF(SsMeshDivType);
+SPRITESTUDIO6DSK_DECLARE_ENUM_STRING_DEF(SsMeshDivType);
 
 struct SsTriangle
 {
@@ -986,5 +987,6 @@ public:
 
 };
 
+}	// namespace spritestudio6
 
 #endif

--- a/Common/Loader/ssvalue.cpp
+++ b/Common/Loader/ssvalue.cpp
@@ -4,19 +4,22 @@
 #include "sscharconverter.h"
 
 
+namespace spritestudio6
+{
+
 //SsValue用のシリアライザ
 void	SsValueSeriarizer( ISsXmlArchiver* ar , SsValue& v , const std::string key) 
 {
 
 	//インプット
-	XMLElement* e = ar->getxml();
+	libXML::XMLElement* e = ar->getxml();
 	if ( key != "" )
 	{
 		e = e->FirstChildElement( key.c_str() );
 	}
 	if ( e )
 	{
-		XMLElement* child = e->FirstChildElement();
+		libXML::XMLElement* child = e->FirstChildElement();
 
 		if ( child == 0 )
 		{
@@ -41,7 +44,7 @@ void	SsValueSeriarizer( ISsXmlArchiver* ar , SsValue& v , const std::string key)
 			std::string enc_str = str;
 			v = SsValueSeriarizer__MakeValue( enc_str.c_str() );
 		}else{
-			XMLElement* ce = child;
+			libXML::XMLElement* ce = child;
 
 			SsHash hash;
 			while(ce)
@@ -51,7 +54,7 @@ void	SsValueSeriarizer( ISsXmlArchiver* ar , SsValue& v , const std::string key)
 				{
 					std::string enc_str = str;
 					hash[ce->Name()] = SsValueSeriarizer__MakeValue( enc_str.c_str() );
-					ce = (XMLElement*)ce->NextSibling();
+					ce = (libXML::XMLElement*)ce->NextSibling();
 				}else{
 					//さらに子構造があるようだ
 					//さらに子構造があるようだ
@@ -61,7 +64,7 @@ void	SsValueSeriarizer( ISsXmlArchiver* ar , SsValue& v , const std::string key)
 					SsValue tempv;
 					SsValueSeriarizer( &ar , tempv , "");
 					hash[ce->Name()] = tempv;					
-					ce = (XMLElement*)ce->NextSibling();
+					ce = (libXML::XMLElement*)ce->NextSibling();
 				}
 			}
 
@@ -74,3 +77,5 @@ void	SsValueSeriarizer( ISsXmlArchiver* ar , SsValue& v , const std::string key)
 	//assert(e);
 
 }
+
+}	// namespace spritestudio6

--- a/Common/Loader/ssvalue.h
+++ b/Common/Loader/ssvalue.h
@@ -7,6 +7,9 @@
 #include <vector>
 #include <cassert>
 
+namespace spritestudio6
+{
+
 class SsValue;
 
 typedef	wchar_t		SsChar;
@@ -174,7 +177,7 @@ public:
 		return false;
 	}
 
-	SSSERIALIZE_BLOCK
+	SPRITESTUDIO6DSK_SERIALIZE_BLOCK
 	{
 		SsValueSeriarizer( ar , *this ,"" );	
 	}
@@ -333,5 +336,6 @@ inline static  SsValue	SsValueSeriarizer__MakeValue( const char* v )
 
 
 
+}	// namespace spritestudio6
 
 #endif


### PR DESCRIPTION
※OSSであるstb_imageとメルセンヌツイスタ乱数については、行っていません。
※マクロも極力置き換えて名前空間の下に配置しましたが、一部糖衣的構文置換系が置き換えできないため、それらには「SPRITESTUDIO6SD_」の接頭を付けて差別化（ただし「SPRITESTUDIOSDK_VERSION」などバージョンについては元のままの名称にしてあります）
※一部機械的に解消できる警告などについて解消した。