### PR TITLE
[SDK]

### DIFF
--- a/Build/Converter/main.cpp
+++ b/Build/Converter/main.cpp
@@ -1935,6 +1935,7 @@ bool parseOption(Options& options, const std::string& opt, ArgumentPointer& args
 		else if (outputFormat == "c") options.outputFormat = OUTPUT_FORMAT_FLAG_CSOURCE;
 		else if (outputFormat == "ssfb") options.outputFormat = OUTPUT_FORMAT_FLAG_SSFB;
 	}
+#ifdef _WIN32
 	else if (opt == "-c")
 	{
 		if (!args.hasNext()) return false;
@@ -1943,6 +1944,8 @@ bool parseOption(Options& options, const std::string& opt, ArgumentPointer& args
 		if (argumentEncode == "utf8") options.argumentEncode = ARGUMENT_ENCODE_UTF8;
 		else if (argumentEncode == "sjis") options.argumentEncode = ARGUMENT_ENCODE_SJIS;
 	}
+#else
+#endif	/* def _WIN32 */
 	else
 	{
 		// unknown
@@ -1994,8 +1997,12 @@ bool parseArguments(Options& options, int argc, const char* argv[], std::string&
 			switch(options.argumentEncode)
 			{
 			case ARGUMENT_ENCODE_SJIS:
+#ifdef _WIN32
 				nameUTF8 = 	spritestudio6::SsCharConverter::sjis_to_utf8(name);;
 				break;
+#else
+				/* Fall-Through */
+#endif	/* def _WIN32 */
 
 			case ARGUMENT_ENCODE_UTF8:
 			default:

--- a/Build/Converter/main.cpp
+++ b/Build/Converter/main.cpp
@@ -214,7 +214,6 @@ static const spritestudio6::SsPartState* findState(std::list<spritestudio6::SsPa
 // kindArgumentEncodeはARGUMENT_ENCODE_～の値で、強制指定する場合だけ有効な値を与えてください。
 static std::string convert_console_string(const std::string& srcUTF8, int kindArgumentEncode=-1)
 {
-#ifdef _WIN32
 	std::string dst;
 	if(kindArgumentEncode < 0)
 	{
@@ -238,9 +237,6 @@ static std::string convert_console_string(const std::string& srcUTF8, int kindAr
 	}
 
 	return dst;
-#else
-
-#endif // def _WIN32
 }
 
 

--- a/Build/Viewer2/Source/Model/Loader.cpp
+++ b/Build/Viewer2/Source/Model/Loader.cpp
@@ -84,7 +84,8 @@ void AsyncProjectLoader::run()
 	{
 		p->changeState(p->stateLoading.get());
 
-		std::string fileName = spritestudio6::SsCharConverter::convert_path_string(projectName.toStdString());
+//		std::string fileName = spritestudio6::SsCharConverter::convert_path_string(projectName.toStdString());
+		std::string fileName = projectName.toStdString();
 
 		spritestudio6::SsProject* proj = spritestudio6::ssloader_sspj::Load(fileName);
 

--- a/Common/Animator/ssplayer_animedecode.cpp
+++ b/Common/Animator/ssplayer_animedecode.cpp
@@ -1,4 +1,4 @@
-﻿#include <stdio.h>
+#include <stdio.h>
 #include <cstdlib>
 #include <time.h>   //時間
 

--- a/Common/Animator/ssplayer_animedecode.h
+++ b/Common/Animator/ssplayer_animedecode.h
@@ -1,4 +1,4 @@
-﻿#ifndef __SSPLAYER_ANIMEDECODE__
+#ifndef __SSPLAYER_ANIMEDECODE__
 #define __SSPLAYER_ANIMEDECODE__
 
 #include "../Loader/ssloader.h"

--- a/Common/Animator/ssplayer_cellmap.cpp
+++ b/Common/Animator/ssplayer_cellmap.cpp
@@ -7,6 +7,7 @@
 #include "ssplayer_animedecode.h"
 #include "ssplayer_matrix.h"
 #include "ssplayer_render.h"
+#include "sscharconverter.h"
 
 #include "../Helper/DebugPrint.h"
 
@@ -63,8 +64,11 @@ SsCelMapLinker::SsCelMapLinker(SsCellMap* cellmap, SsString filePath)
 	fullpath = fullpath + path2file(cellmap->imagePath);
 	fullpath = nomarizeFilename(fullpath);
 
-	DEBUG_PRINTF("TextureFile Load %s \n", fullpath.c_str());
-	tex = SSTextureFactory::loadTexture(fullpath.c_str());
+//	DEBUG_PRINTF("TextureFile Load %s \n", fullpath.c_str());
+//	tex = SSTextureFactory::loadTexture(fullpath.c_str());
+	SsString filePathFs = SsCharConverter::convert_path_string( fullpath );
+	DEBUG_PRINTF("TextureFile Load %s \n", filePathFs.c_str());
+	tex = SSTextureFactory::loadTexture(filePathFs.c_str());
 
 }
 

--- a/Common/Loader/sscharconverter.cpp
+++ b/Common/Loader/sscharconverter.cpp
@@ -1,4 +1,4 @@
-#include "sscharconverter.h"
+ï»¿#include "sscharconverter.h"
 
 #ifdef __APPLE__
     #include "TargetConditionals.h"
@@ -64,25 +64,23 @@ std::string SsCharConverter::utf8_to_sjis(const std::string &src) {
 
 std::string SsCharConverter::sjis_to_utf8(const std::string &src) {
 #if __APPLE__ && TARGET_OS_MAC
-    /* MEMO: ‚±‚±A‚Ç‚È‚½‚©Mac”Å‚ğ‹LÚ‚¨Šè‚¢‚Å‚«‚Ü‚¹‚ñ‚Å‚µ‚å‚¤‚©H Yuzu. */
-    /*       Mac‚Ìê‡‚ÍAConverter‚ÌƒRƒ}ƒ“ƒhƒ‰ƒCƒ“‚Ì‰ğÍ‚Å‚µ‚©g—p‚µ‚È‚¢‚Æv‚¢‚Ü‚·B */
-
     // TODO: impl
+    /* MEMO: Macã®å ´åˆã¯é€šã—ã¦UTF-8ãªã®ã§ã€ï¼ˆåŸå‰‡ã¨ã—ã¦å¤‰æ›ã®å¿…è¦ã¯ãªã„ã®ã§ï¼‰ä»Šã¯è¤‡è£½ã ã‘ã—ã¦è¿”ã—ã¦ã„ã¾ã™ã€‚ */
     return std::string(src);
 #elif _WIN32 || _WIN64
     enum Constant {
         SIZE_BUFFER_WTCHAR = 2048,
     };
-    wchar_t buffer[Constant::SIZE_BUFFER_WTCHAR];   //I’[•¶š‚İ‚Ì’·‚³‚Å‚ ‚é‚±‚Æ‚É’ˆÓ
+    wchar_t buffer[Constant::SIZE_BUFFER_WTCHAR];   //çµ‚ç«¯æ–‡å­—è¾¼ã¿ã®é•·ã•ã§ã‚ã‚‹ã“ã¨ã«æ³¨æ„
     size_t srcWCharSize = 0;
-    // MEMO: src‚ªˆê“xc_str‚ğ’Ê‚Á‚Ädata()‚Éƒoƒbƒtƒ@‚ªŒ`¬‚³‚ê‚Ä‚¢‚é‚©•ÛØ‚ª‚È‚¢‚Ì‚ÅAc_str‚ğ‚µ‚Ä‚¨‚­i•W€“I‚Èstd::string‚ÌÀ‘•‚È‚ç‘åä•v‚È‚Í‚¸‚È‚Ì‚ÅA”O‚Ì‚½‚ßjB
+    // MEMO: srcãŒä¸€åº¦c_strã‚’é€šã£ã¦data()ã«ãƒãƒƒãƒ•ã‚¡ãŒå½¢æˆã•ã‚Œã¦ã„ã‚‹ã‹ä¿è¨¼ãŒãªã„ã®ã§ã€c_strã‚’ã—ã¦ãŠãï¼ˆæ¨™æº–çš„ãªstd::stringã®å®Ÿè£…ãªã‚‰å¤§ä¸ˆå¤«ãªã¯ãšãªã®ã§ã€å¿µã®ãŸã‚ï¼‰ã€‚
     if (::_mbstowcs_s_l(&srcWCharSize, buffer, Constant::SIZE_BUFFER_WTCHAR, src.c_str(), _TRUNCATE, ::_create_locale(LC_ALL, "jpn")) != 0) {
         throw std::system_error{ errno, std::system_category() };
     }
-    //MEMO: æ‚Éƒoƒbƒtƒ@‚ğw’è’·‚Åİ’u‚µ‚Ä.data()‚É’¼ÚƒŒƒ“ƒ_ƒŠƒ“ƒO‚µ‚Ä‚µ‚Ü‚¤‚ÆAƒoƒbƒtƒ@‚ÉI’[•¶š‚ª“ü‚ç‚È‚¢ê‡‚ª‚ ‚é‚½‚ßcc
+    //MEMO: å…ˆã«ãƒãƒƒãƒ•ã‚¡ã‚’æŒ‡å®šé•·ã§è¨­ç½®ã—ã¦.data()ã«ç›´æ¥ãƒ¬ãƒ³ãƒ€ãƒªãƒ³ã‚°ã—ã¦ã—ã¾ã†ã¨ã€ãƒãƒƒãƒ•ã‚¡ã«çµ‚ç«¯æ–‡å­—ãŒå…¥ã‚‰ãªã„å ´åˆãŒã‚ã‚‹ãŸã‚â€¦â€¦
     std::wstring srcWCharData(buffer);
     srcWCharData.shrink_to_fit();
-    srcWCharSize = srcWCharData.size(); // Äæ“¾
+    srcWCharSize = srcWCharData.size(); // å†å–å¾—
 
     auto const destByteSize = ::WideCharToMultiByte(CP_UTF8, 0U, srcWCharData.data(), srcWCharSize, nullptr, 0, nullptr, nullptr);
     std::vector<char> dest(destByteSize, L'\0');

--- a/Common/Loader/sscharconverter.cpp
+++ b/Common/Loader/sscharconverter.cpp
@@ -7,6 +7,7 @@
     #endif
 #elif _WIN32 || _WIN64
     #include <Windows.h>
+    #include <locale.h>
     #include <vector>
     #include <system_error>
 #else
@@ -37,12 +38,13 @@ std::string SsCharConverter::utf8_to_sjis(const std::string &src) {
     CFRelease(srcStr);
     return dstStr;
 #elif _WIN32 || _WIN64
-    auto const srcWCharSize = ::MultiByteToWideChar(CP_UTF8, 0U, src.data(), -1, nullptr, 0U);
+    auto const srcSize = src.size();
+    auto const srcWCharSize = ::MultiByteToWideChar(CP_UTF8, 0U, src.data(), srcSize, nullptr, 0U);
     std::vector<wchar_t> srcWCharData(srcWCharSize, L'\0');
-    if (::MultiByteToWideChar(CP_UTF8, 0U, src.data(), -1, srcWCharData.data(), (int)(srcWCharData.size())) == 0) {
+    if (::MultiByteToWideChar(CP_UTF8, 0U, src.data(), srcSize, srcWCharData.data(), (int)srcWCharSize) == 0) {
         throw std::system_error{ static_cast<int>(::GetLastError()), std::system_category() };
     }
-    srcWCharData.resize(std::char_traits<wchar_t>::length(srcWCharData.data()));
+//    srcWCharData.resize(std::char_traits<wchar_t>::length(srcWCharData.data()));
     srcWCharData.shrink_to_fit();
 
     std::wstring srcWChar(srcWCharData.begin(), srcWCharData.end());
@@ -59,6 +61,43 @@ std::string SsCharConverter::utf8_to_sjis(const std::string &src) {
     return std::string(src);
 #endif
 }
+
+std::string SsCharConverter::sjis_to_utf8(const std::string &src) {
+#if __APPLE__ && TARGET_OS_MAC
+    /* MEMO: ここ、どなたかMac版を記載お願いできませんでしょうか？ Yuzu. */
+    /*       Macの場合は、Converterのコマンドラインの解析でしか使用しないと思います。 */
+
+    // TODO: impl
+    return std::string(src);
+#elif _WIN32 || _WIN64
+    enum Constant {
+        SIZE_BUFFER_WTCHAR = 2048,
+    };
+    wchar_t buffer[Constant::SIZE_BUFFER_WTCHAR];   //終端文字込みの長さであることに注意
+    size_t srcWCharSize = 0;
+    // MEMO: srcが一度c_strを通ってdata()にバッファが形成されているか保証がないので、c_strをしておく（標準的なstd::stringの実装なら大丈夫なはずなので、念のため）。
+    if (::_mbstowcs_s_l(&srcWCharSize, buffer, Constant::SIZE_BUFFER_WTCHAR, src.c_str(), _TRUNCATE, ::_create_locale(LC_ALL, "jpn")) != 0) {
+        throw std::system_error{ errno, std::system_category() };
+    }
+    //MEMO: 先にバッファを指定長で設置して.data()に直接レンダリングしてしまうと、バッファに終端文字が入らない場合があるため……
+    std::wstring srcWCharData(buffer);
+    srcWCharData.shrink_to_fit();
+    srcWCharSize = srcWCharData.size(); // 再取得
+
+    auto const destByteSize = ::WideCharToMultiByte(CP_UTF8, 0U, srcWCharData.data(), srcWCharSize, nullptr, 0, nullptr, nullptr);
+    std::vector<char> dest(destByteSize, L'\0');
+    if (::WideCharToMultiByte(CP_UTF8, 0U, srcWCharData.data(), srcWCharSize, dest.data(), destByteSize, nullptr, nullptr) == 0) {
+        throw std::system_error{ static_cast<int>(::GetLastError()), std::system_category() };
+    }
+//    dest.shrink_to_fit();
+
+    return std::string(dest.begin(), dest.end());
+#else
+    // TODO: impl
+    return std::string(src);
+#endif
+}
+
 
 std::string SsCharConverter::convert_path_string(const std::string &str) {
     std::string dst;

--- a/Common/Loader/sscharconverter.h
+++ b/Common/Loader/sscharconverter.h
@@ -9,6 +9,7 @@ namespace spritestudio6
 class SsCharConverter {
 public:
 	static std::string utf8_to_sjis(const std::string &src);
+	static std::string sjis_to_utf8(const std::string &src);
 	static std::string convert_path_string(const std::string &str);
 };
 

--- a/Common/Loader/ssloader.h
+++ b/Common/Loader/ssloader.h
@@ -128,7 +128,7 @@
 
 //SDKを更新する場合はバージョン番号を変更してください
 //MEMO: 本マクロについては、SPRITESTUDIO6SDKに限らないラベルのため、SPRITESTUDIO6SDK_の接頭にしていません。
-#define SPRITESTUDIOSDK_VERSION "SpriteStudio 6 SDK Version 1.7.4"
+#define SPRITESTUDIOSDK_VERSION "SpriteStudio 6 SDK Version 1.8.0"
 
 
 #endif

--- a/Common/Loader/ssloader_sspj.cpp
+++ b/Common/Loader/ssloader_sspj.cpp
@@ -146,13 +146,16 @@ SsSequence*		SsProject::findSequence( SsString& sequencePackName , SsString& Seq
 SsProject*	ssloader_sspj::Load(const std::string& filename )
 {
 	libXML::XMLDocument xml;
-	if ( libXML::XML_SUCCESS == xml.LoadFile( filename.c_str() ) )
+	std::string filenameSSPJ = SsCharConverter::convert_path_string( filename );
+
+	if ( libXML::XML_SUCCESS == xml.LoadFile( filenameSSPJ.c_str() ) )
 	{
 		SsXmlIArchiver ar( xml.GetDocument() , "SpriteStudioProject" );
 
 		SsProject* proj = new SsProject();
 		proj->__Serialize( &ar );
-		std::string project_filepath = SsCharConverter::convert_path_string(path2dir( filename ));
+//		std::string project_filepath = SsCharConverter::convert_path_string( path2dir( filename ) );
+		std::string project_filepath = path2dir( filename );
 		proj->setFilepath( project_filepath );
 
 		if ( checkFileVersion(proj->version, SPRITESTUDIO6_SSPJVERSION) == false )

--- a/Common/Loader/ssstring_uty.cpp
+++ b/Common/Loader/ssstring_uty.cpp
@@ -1,4 +1,5 @@
 ﻿#include "ssstring_uty.h"
+#include "sscharconverter.h"
 
 #ifdef _WIN32
 #include <direct.h>
@@ -87,25 +88,28 @@ bool	is_digit_string( std::string &in_str , bool* is_priod )
 std::string getFullPath( const std::string& basePath , const std::string &relPath )
 {
 #ifdef _WIN32
-	static char	curPath[_MAX_PATH];
+	char	curPath[_MAX_PATH];
+	char	buffer_[_MAX_PATH];
+	std::string basePathFs;
+	std::string relPathFs;
+	if( basePath.size() > 0 )
+		basePathFs = SsCharConverter::convert_path_string( basePath );
+	if( relPath.size() > 0 )
+		relPathFs = SsCharConverter::convert_path_string( relPath );
 
-#if 0	// MEMO: エンバグしていると困るので、一応まだ残しておく
-	_chdir( basePath.c_str() );
 	_getcwd( curPath , _MAX_PATH ); 
-#else
-	_getcwd( curPath , _MAX_PATH ); 
-	_chdir( basePath.c_str() );
-#endif
+	_chdir( basePathFs.c_str() );
 
-	static char	buffer_[_MAX_PATH];
-	_fullpath( buffer_ , relPath.c_str() , _MAX_PATH );
-
+	_fullpath( buffer_ , relPathFs.c_str() , _MAX_PATH );
+	
 	_chdir( curPath );
 
-	std::string temp = buffer_;
+	std::string temp( buffer_ );
 	temp+= "\\";
+	// MEMO: Windowsの場合、上記API群で返ってくるパスのエンコードはSJISなことに注意
+	std::string rv = SsCharConverter::sjis_to_utf8( temp );
 
-	return temp;
+	return rv;
 #else
 	char	buffer_[2048];
 	char	curPath[2048];


### PR DESCRIPTION
・ssloaderに与えるファイルパスとssXe関係のクラスに記録されているパス名などを、表見は全てstd::stringのUTF-8エンコード文字列に統一。
※全角パスでのアクセスが可能になっているはずです。
※Mac用のsjis_to_utf8関数が未実装です。