### PR TITLE
CMAKEにMSVCの際にソースをUTF8とみなすオプションを追加

### DIFF
--- a/Build/Converter/CMakeLists.txt
+++ b/Build/Converter/CMakeLists.txt
@@ -5,6 +5,11 @@ project(Ss6Converter)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+if(MSVC)
+add_compile_options("$<$<C_COMPILER_ID:MSVC>:/utf-8>")
+add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
+endif()
+
 # command options
 option(ENABLE_CCACHE "Enable ccache?" ON)
 # enable ccache

--- a/Common/Animator/CMakeLists.txt
+++ b/Common/Animator/CMakeLists.txt
@@ -5,6 +5,12 @@ project(ssAnimator)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+if(MSVC)
+add_compile_options("$<$<C_COMPILER_ID:MSVC>:/utf-8>")
+add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
+endif()
+
+
 set(ssAnimator_SRCS
     ssplayer_cellmap.cpp
     ssplayer_PartState.cpp

--- a/Common/Animator/ssplayer_animedecode.cpp
+++ b/Common/Animator/ssplayer_animedecode.cpp
@@ -2,6 +2,8 @@
 #include <cstdlib>
 #include <time.h>   //時間
 
+
+
 #include "../Loader/ssloader.h"
 #include "ssplayer_animedecode.h"
 #include "ssplayer_matrix.h"
@@ -10,6 +12,8 @@
 #include "ssplayer_effect2.h"
 #include "ssplayer_mesh.h"
 #include "ssInterpolation.h"
+
+
 
 namespace spritestudio6
 {

--- a/Common/Animator/ssplayer_animedecode.h
+++ b/Common/Animator/ssplayer_animedecode.h
@@ -22,144 +22,144 @@ namespace spritestudio6
 {
 
 
-//パーツとアニメを関連付ける
-typedef std::pair<SsPart*,SsPartAnime*>	SsPartAndAnime;
+	//パーツとアニメを関連付ける
+	typedef std::pair<SsPart*,SsPartAnime*>	SsPartAndAnime;
 
 
-//パーツのソート順
-class SsPartStateLess
-{
-public:
-	bool operator()(const SsPartState* lhs, const SsPartState* rhs) const
+	//パーツのソート順
+	class SsPartStateLess
 	{
-		if (lhs->prio == rhs->prio)
-			return lhs->index < rhs->index;
-		return lhs->prio < rhs->prio;
-	}
-};
+	public:
+		bool operator()(const SsPartState* lhs, const SsPartState* rhs) const
+		{
+			if (lhs->prio == rhs->prio)
+				return lhs->index < rhs->index;
+			return lhs->prio < rhs->prio;
+		}
+	};
 
 
 
-class SsAnimeDecoder
-{
-public:
+	class SsAnimeDecoder
+	{
+	public:
 
-private:
+	private:
 
-	///プロジェクト情報
-	SsProject* project;
+		///プロジェクト情報
+		SsProject* project;
 		
-	///パーツ情報とパーツアニメーションを結びつけアレイにしたもの
-	std::vector<SsPartAndAnime>		partAnime;
-	std::vector<SsPartAndAnime>		setupPartAnime;		///セットアップデータ
+		///パーツ情報とパーツアニメーションを結びつけアレイにしたもの
+		std::vector<SsPartAndAnime>		partAnime;
+		std::vector<SsPartAndAnime>		setupPartAnime;		///セットアップデータ
 
-	///パーツ名からアニメ情報をとるために使うもし、そういった用途が無い場合はローカル変数でも機能する
-	std::map<SsString,SsPartAnime*> partAnimeDic;
-	std::map<SsString, SsPartAnime*>setupPartAnimeDic;	///セットアップデータ
+		///パーツ名からアニメ情報をとるために使うもし、そういった用途が無い場合はローカル変数でも機能する
+		std::map<SsString,SsPartAnime*> partAnimeDic;
+		std::map<SsString, SsPartAnime*>setupPartAnimeDic;	///セットアップデータ
 
-	std::unique_ptr<SsCellMapList>	curCellMapManager;		///アニメに関連付けられているセルマップ
+		std::unique_ptr<SsCellMapList>	curCellMapManager;		///アニメに関連付けられているセルマップ
 
-	std::unique_ptr<std::vector<SsPartState>>	partState;	///パーツの現在の状態が格納されています。
+		std::unique_ptr<std::vector<SsPartState>>	partState;	///パーツの現在の状態が格納されています。
 
-	std::list<SsPartState*>			sortList;			///ソート状態
-	std::list<SsPartState*>			partStatesMask_;	///マスクテンポラリ
-	std::vector<SsPartState*>		maskIndexList;
-
-
-	int				seedOffset;							//エフェクトのシードへ影響
-	float			nowPlatTime;
-	float			nowPlatTimeOld;						//前のフレームで再生した時間
-	float			frameDelta;
-	int				curAnimeStartFrame;
-	int				curAnimeEndFrame;
-	int				curAnimeTotalFrame;
-	int				curAnimeFPS;
-	SsAnimation*	curAnimation;
-	bool			instancePartsHide;
-	bool			maskFuncFlag;						//マスク機能（初期化、描画）を有効にするか？インスタンスパーツ内のマスク対応
-	bool			maskParentSetting;					//親のマスク対象
-	SsSequence*		curSequence;
-
-	size_t			stateNum;
-
-	std::unique_ptr<SsMeshAnimator>	meshAnimator;
-	SsModel*		myModel;
-
-private:
-	void	updateState( int nowTime , SsPart* part , SsPartAnime* part_anime , SsPartState* state );
-	void	updateInstance( int nowTime , SsPart* part , SsPartAnime* part_anime , SsPartState* state );
-	void	updateEffect( float frameDelta , int nowTime , SsPart* part , SsPartAnime* part_anime , SsPartState* state );
+		std::list<SsPartState*>			sortList;			///ソート状態
+		std::list<SsPartState*>			partStatesMask_;	///マスクテンポラリ
+		std::vector<SsPartState*>		maskIndexList;
 
 
-	void	updateMatrix(SsPart* part , SsPartAnime* anime , SsPartState* state);
+		int				seedOffset;							//エフェクトのシードへ影響
+		float			nowPlatTime;
+		float			nowPlatTimeOld;						//前のフレームで再生した時間
+		float			frameDelta;
+		int				curAnimeStartFrame;
+		int				curAnimeEndFrame;
+		int				curAnimeTotalFrame;
+		int				curAnimeFPS;
+		SsAnimation*	curAnimation;
+		bool			instancePartsHide;
+		bool			maskFuncFlag;						//マスク機能（初期化、描画）を有効にするか？インスタンスパーツ内のマスク対応
+		bool			maskParentSetting;					//親のマスク対象
+		SsSequence*		curSequence;
 
-	void	updateVertices(SsPart* part , SsPartAnime* anime , SsPartState* state);
+		size_t			stateNum;
 
-    int		CalcAnimeLabel2Frame(const SsString& str, int offset, SsAnimation* Animation  );
-	int		findAnimetionLabel(const SsString& str, SsAnimation* Animation);
-	bool	getFirstCell(SsPart* part, SsCellValue& out);
+		std::unique_ptr<SsMeshAnimator>	meshAnimator;
+		SsModel*		myModel;
+
+	private:
+		void	updateState( int nowTime , SsPart* part , SsPartAnime* part_anime , SsPartState* state );
+		void	updateInstance( int nowTime , SsPart* part , SsPartAnime* part_anime , SsPartState* state );
+		void	updateEffect( float frameDelta , int nowTime , SsPart* part , SsPartAnime* part_anime , SsPartState* state );
 
 
-public:
-	SsAnimeDecoder();
-	virtual ~SsAnimeDecoder()
-	{
-		//念のため解放（スマートポインタなので実用上問題ないはずだが明示性として）
-		curCellMapManager.reset();
-		partState.reset();
-		meshAnimator.reset();
-	}
+		void	updateMatrix(SsPart* part , SsPartAnime* anime , SsPartState* state);
 
-	virtual void	update( float frameDelta = 1.0f );
-	virtual void	draw();
+		void	updateVertices(SsPart* part , SsPartAnime* anime , SsPartState* state);
 
-	void	setAnimation( SsModel*	model , SsAnimation* anime , SsCellMapList* cellmap , SsProject* sspj=0 );
-//	void	setAnimation(SsModel*	model, SsAnimation* anime, SsAnimePack *animepack , SsCellMapList* cellmap, SsProject* sspj = 0);
-	void	setSequence( SsSequence* sequence , SsProject* sspj=0 );
+		int		CalcAnimeLabel2Frame(const SsString& str, int offset, SsAnimation* Animation  );
+		int		findAnimetionLabel(const SsString& str, SsAnimation* Animation);
+		bool	getFirstCell(SsPart* part, SsCellValue& out);
 
-	void	setPlayFrame( float time ) { nowPlatTime = time; }
-	int		getAnimeStartFrame() { return curAnimeStartFrame; }
-	int		getAnimeEndFrame() { return curAnimeEndFrame; }
-	int		getAnimeTotalFrame() { return curAnimeTotalFrame; }
-	int		getAnimeFPS() {	return curAnimeFPS; }		
 
-	int		getSequenceItemCount() { return (int)(curSequence->list.size()); }
-	SsSequenceItem*	getSequenceItem( int iIndex ) { return curSequence->list[iIndex]; }
+	public:
+		SsAnimeDecoder();
+		virtual ~SsAnimeDecoder()
+		{
+			//念のため解放（スマートポインタなので実用上問題ないはずだが明示性として）
+			curCellMapManager.reset();
+			partState.reset();
+			meshAnimator.reset();
+		}
 
-	size_t	getStateNum() { return stateNum; }
-	std::vector<SsPartState>& getPartState() { return *(partState.get()); }
-	SsModel*	getMyModel(){return myModel;}
+		virtual void	update( float frameDelta = 1.0f );
+		virtual void	draw();
 
-	std::list<SsPartState*>&		getPartSortList(){return sortList;}
-	std::vector<SsPartAndAnime>&	getPartAnime(){ return	partAnime; }
+		void	setAnimation( SsModel*	model , SsAnimation* anime , SsCellMapList* cellmap , SsProject* sspj=0 );
+	//	void	setAnimation(SsModel*	model, SsAnimation* anime, SsAnimePack *animepack , SsCellMapList* cellmap, SsProject* sspj = 0);
+		void	setSequence( SsSequence* sequence , SsProject* sspj=0 );
+
+		void	setPlayFrame( float time ) { nowPlatTime = time; }
+		int		getAnimeStartFrame() { return curAnimeStartFrame; }
+		int		getAnimeEndFrame() { return curAnimeEndFrame; }
+		int		getAnimeTotalFrame() { return curAnimeTotalFrame; }
+		int		getAnimeFPS() {	return curAnimeFPS; }		
+
+		int		getSequenceItemCount() { return (int)(curSequence->list.size()); }
+		SsSequenceItem*	getSequenceItem( int iIndex ) { return curSequence->list[iIndex]; }
+
+		size_t	getStateNum() { return stateNum; }
+		std::vector<SsPartState>& getPartState() { return *(partState.get()); }
+		SsModel*	getMyModel(){return myModel;}
+
+		std::list<SsPartState*>&		getPartSortList(){return sortList;}
+		std::vector<SsPartAndAnime>&	getPartAnime(){ return	partAnime; }
 	
-	template<typename mytype> int	SsGetKeyValue( SsPart* part, int time , SsAttribute* attr , mytype&  value );
-	template<typename mytype> void	SsInterpolationValue( int time , const SsKeyframe* leftkey , const SsKeyframe* rightkey , mytype& v );
-	void	SsInterpolationValue( int time , const SsKeyframe* leftkey , const SsKeyframe* rightkey , SsCellValue& v );
-	void	SsInterpolationValue( int time , const SsKeyframe* leftkey , const SsKeyframe* rightkey , SsPartsColorAnime& v );
-	void	SsInterpolationValue( int time , const SsKeyframe* leftkey , const SsKeyframe* rightkey , SsColorAnime& v );
-	void	SsInterpolationValue( int time , const SsKeyframe* leftkey , const SsKeyframe* rightkey , SsShaderAnime& v );
-	void	SsInterpolationValue( int time , const SsKeyframe* leftkey , const SsKeyframe* rightkey , SsVertexAnime& v );
-	void	SsInterpolationValue( int time , const SsKeyframe* leftkey , const SsKeyframe* rightkey , SsSignalAttr& v );
-	void	SsInterpolationValue( int time , const SsKeyframe* leftkey , const SsKeyframe* rightkey , SsInstanceAttr& v );
-	void	SsInterpolationValue( int time , const SsKeyframe* leftkey , const SsKeyframe* rightkey , SsEffectAttr& v );
-	void	SsInterpolationValue( int time , const SsKeyframe* leftkey , const SsKeyframe* rightkey , SsDeformAttr& v );
+		template<typename mytype> int	SsGetKeyValue( SsPart* part, int time , SsAttribute* attr , mytype&  value );
+		template<typename mytype> void	SsInterpolationValue( int time , const SsKeyframe* leftkey , const SsKeyframe* rightkey , mytype& v );
+		void	SsInterpolationValue( int time , const SsKeyframe* leftkey , const SsKeyframe* rightkey , SsCellValue& v );
+		void	SsInterpolationValue( int time , const SsKeyframe* leftkey , const SsKeyframe* rightkey , SsPartsColorAnime& v );
+		void	SsInterpolationValue( int time , const SsKeyframe* leftkey , const SsKeyframe* rightkey , SsColorAnime& v );
+		void	SsInterpolationValue( int time , const SsKeyframe* leftkey , const SsKeyframe* rightkey , SsShaderAnime& v );
+		void	SsInterpolationValue( int time , const SsKeyframe* leftkey , const SsKeyframe* rightkey , SsVertexAnime& v );
+		void	SsInterpolationValue( int time , const SsKeyframe* leftkey , const SsKeyframe* rightkey , SsSignalAttr& v );
+		void	SsInterpolationValue( int time , const SsKeyframe* leftkey , const SsKeyframe* rightkey , SsInstanceAttr& v );
+		void	SsInterpolationValue( int time , const SsKeyframe* leftkey , const SsKeyframe* rightkey , SsEffectAttr& v );
+		void	SsInterpolationValue( int time , const SsKeyframe* leftkey , const SsKeyframe* rightkey , SsDeformAttr& v );
 
 
-	void	setInstancePartsHide(bool hide){
-		instancePartsHide = hide;
-	}
-	void	restart();
-	void	reset();
+		void	setInstancePartsHide(bool hide){
+			instancePartsHide = hide;
+		}
+		void	restart();
+		void	reset();
 
-	void	setSeedOffset(int a ){ seedOffset = a; }
-	int		getSeedOffset(){ return seedOffset; }
+		void	setSeedOffset(int a ){ seedOffset = a; }
+		int		getSeedOffset(){ return seedOffset; }
 
-	void setMaskFuncFlag(bool flg);									//マスク用ステンシルバッファの初期化を行うか
-	void setMaskParentSetting(bool flg);							//親のマスク対象を設定する
-	bool getMaskParentSetting(void) { return maskParentSetting; };	//設定された親のマスク対象を取得する
+		void setMaskFuncFlag(bool flg);									//マスク用ステンシルバッファの初期化を行うか
+		void setMaskParentSetting(bool flg);							//親のマスク対象を設定する
+		bool getMaskParentSetting(void) { return maskParentSetting; };	//設定された親のマスク対象を取得する
 
-};
+	};
 
 
 }	// namespace spritestudio6

--- a/Common/Animator/ssplayer_macro.h
+++ b/Common/Animator/ssplayer_macro.h
@@ -5,19 +5,19 @@
 namespace spritestudio6
 {
 
-constexpr auto __PI__ = (3.14159265358979323846f);
-// #define RadianToDegree(Radian) ((double)Radian * (180.0f / __PI__))
-template<typename T> inline double RadianToDegree(T Radian)
-{
-	return((double)Radian * (180.0f / __PI__));
-}
-// #define DegreeToRadian(Degree) ((double)Degree * (__PI__ / 180.0f))
-template<typename T> inline double DegreeToRadian(T Degree)
-{
-	return((double)Degree * (__PI__ / 180.0f));
-}
+	constexpr auto __PI__ = (3.14159265358979323846f);
+	// #define RadianToDegree(Radian) ((double)Radian * (180.0f / __PI__))
+	template<typename T> inline double RadianToDegree(T Radian)
+	{
+		return((double)Radian * (180.0f / __PI__));
+	}
+	// #define DegreeToRadian(Degree) ((double)Degree * (__PI__ / 180.0f))
+	template<typename T> inline double DegreeToRadian(T Degree)
+	{
+		return((double)Degree * (__PI__ / 180.0f));
+	}
 
-#define SPRITESTUDIO6SDK_foreach(T, c, i) for(T::iterator i = c.begin(); i!=c.end(); ++i)
+	#define SPRITESTUDIO6SDK_foreach(T, c, i) for(T::iterator i = c.begin(); i!=c.end(); ++i)
 
 }	// namespace spritestudio6
 

--- a/Common/Helper/CMakeLists.txt
+++ b/Common/Helper/CMakeLists.txt
@@ -5,6 +5,11 @@ project(ssHelper)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+if(MSVC)
+add_compile_options("$<$<C_COMPILER_ID:MSVC>:/utf-8>")
+add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
+endif()
+
 set(ssHelper_SRCS
     IsshTexture.cpp
     sshTextureBMP.cpp

--- a/Common/Loader/CMakeLists.txt
+++ b/Common/Loader/CMakeLists.txt
@@ -5,6 +5,11 @@ project(ssLoader)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+if(MSVC)
+add_compile_options("$<$<C_COMPILER_ID:MSVC>:/utf-8>")
+add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
+endif()
+
 set(ssLoader_SRCS
     tinyxml2/tinyxml2.cpp
     ssloader_sspj.cpp
@@ -41,7 +46,7 @@ set(ssLoader_HEADERS
     ssInterpolation.h
     ssattribute.h
     ssstring_uty.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/../Animator/ssplayer_animedecode.h
+#    ${CMAKE_CURRENT_SOURCE_DIR}/../Animator/ssplayer_animedecode.h
     sscharconverter.h
 )
 

--- a/Common/Loader/SsEffectElement.cpp
+++ b/Common/Loader/SsEffectElement.cpp
@@ -5,7 +5,7 @@
 
 
 //loaderのモジュールでレンダラー側のモジュールを参照しているのが筋が良く無い
-
+/*
 #include "SsEffectElement.h"
 #include "ssplayer_animedecode.h"
 #include "ssplayer_effect.h"
@@ -13,7 +13,7 @@
 #include "ssplayer_matrix.h"
 #include "ssplayer_render.h"
 #include "ssplayer_effectfunction.h"
-
+*/
 namespace spritestudio6
 {
 

--- a/Scripts/release_converter_win.bat
+++ b/Scripts/release_converter_win.bat
@@ -15,16 +15,16 @@ if exist "%QT_PREFIX%\bin\windeployqt.exe" (
 )
 @echo on
 
-call %CURDIR%\build_converter_win.bat Release || exit /b 1
-call %CURDIR%\build_convertergui_win.bat Release || exit /b 1
+call "%CURDIR%\build_converter_win.bat" Release || exit /b 1
+call "%CURDIR%\build_convertergui_win.bat" Release || exit /b 1
 
 pushd %BASEDIR%
 rmdir /S /Q Ss6Converter
 mkdir Ss6Converter
-copy %BUILDDIR%\Converter\build\Release\Ss6Converter.exe Ss6Converter\
-copy %BUILDDIR%\Ss6ConverterGUI\Ss6ConverterGUI\Release\Ss6ConverterGUI.exe Ss6Converter\
+copy "%BUILDDIR%\Converter\build\Release\Ss6Converter.exe" Ss6Converter\
+copy "%BUILDDIR%\Ss6ConverterGUI\Ss6ConverterGUI\Release\Ss6ConverterGUI.exe" Ss6Converter\
 %WINDEPLOYQT% --release Ss6Converter\Ss6ConverterGUI.exe || exit /b 1
 powershell compress-archive Ss6Converter Ss6Converter.zip
-move /y Ss6Converter.zip %TOOLSDIR%\
+move /y Ss6Converter.zip "%TOOLSDIR%\"
 rmdir /S /Q Ss6Converter
 popd

--- a/Scripts/release_win.bat
+++ b/Scripts/release_win.bat
@@ -6,5 +6,6 @@ set BUILDDIR=%BASEDIR%\Build
 set TOOLSDIR=%BASEDIR%\Tools
 @echo on
 
-call %CURDIR%\release_converter_win.bat Release || exit /b 1
-call %CURDIR%\release_viewer2_win.bat Release || exit /b 1
+call "%CURDIR%\release_converter_win.bat" Release || exit /b 1
+call "%CURDIR%\release_viewer2_win.bat" Release || exit /b 1
+


### PR DESCRIPTION
CMAKEにMSVCの際にソースをUTF8とみなすオプションを追加
また余分なヘッダー定義を削除