### PR TITLE
Load data individual

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-﻿# Compiled Object files
+# Compiled Object files
 *.slo
 *.lo
 *.o
@@ -101,3 +101,4 @@ Build/Converter/cppfs/
 Build/Ss6ConverterGUI/build-Ss6ConverterGUI-Desktop_Qt_5_15_2_clang_64bit-Debug/
 Build/Ss6ConverterGUI/build-Ss6ConverterGUI-Desktop_Qt_5_15_2_clang_64bit-Debug/
 Build/Ss6ConverterGUI/build-Ss6ConverterGUI-Desktop_Qt_5_15_2_clang_64bit-Release/
+*.obj

--- a/Common/Animator/ssplayer_PartState.cpp
+++ b/Common/Animator/ssplayer_PartState.cpp
@@ -13,7 +13,8 @@ SsPartState::SsPartState() :
 	noCells(false),
 	alphaBlendType(SsBlendType::invalid),
 	refEffect(),
-	meshPart()
+	meshPart(),
+	execDecoder(0)
 {
 	init();
 	effectValue.attrInitialized = false;

--- a/Common/Animator/ssplayer_PartState.h
+++ b/Common/Animator/ssplayer_PartState.h
@@ -96,6 +96,9 @@ struct SsPartState
 
 	SsPart*			part;
 
+	//このStateを処理したdecoder
+	SsAnimeDecoder* execDecoder;
+
 	SsPartState();
 
 	virtual ~SsPartState();

--- a/Common/Animator/ssplayer_animedecode.cpp
+++ b/Common/Animator/ssplayer_animedecode.cpp
@@ -47,7 +47,8 @@ SsAnimeDecoder::SsAnimeDecoder() :
 	seedOffset(0),
 	maskFuncFlag(true),
 	maskParentSetting(true),
-	meshAnimator()
+	meshAnimator(),
+	custom_data(0)
 	{
 	}
 
@@ -821,6 +822,7 @@ void	SsAnimeDecoder::updateState( int nowTime , SsPart* part , SsPartAnime* anim
 
 	//ステートの初期値を設定
 	state->init();
+	state->execDecoder = this;
 	state->inheritRates = part->inheritRates;
 
 	SsPartAnime* setupAnime = setupPartAnimeDic[part->name];	//セットアップアニメを取得する
@@ -1592,7 +1594,7 @@ void	SsAnimeDecoder::draw()
 
 	if (SsCurrentRenderer::getRender() == 0) return;
 
-	SsCurrentRenderer::getRender()->renderSetup();
+	SsCurrentRenderer::getRender()->renderSetup(this);
 
 
 	if (maskFuncFlag == true) //マスク機能が有効（インスタンスのソースアニメではない）
@@ -1616,6 +1618,7 @@ void	SsAnimeDecoder::draw()
 	SPRITESTUDIO6SDK_foreach( std::list<SsPartState*> , sortList , e )
 	{
 		SsPartState* state = (*e);
+		state->execDecoder = this;
 
 		if (state->partType == SsPartType::mask)
 		{

--- a/Common/Animator/ssplayer_animedecode.h
+++ b/Common/Animator/ssplayer_animedecode.h
@@ -85,6 +85,8 @@ namespace spritestudio6
 		std::unique_ptr<SsMeshAnimator>	meshAnimator;
 		SsModel*		myModel;
 
+		void*	custom_data;
+
 	private:
 		void	updateState( int nowTime , SsPart* part , SsPartAnime* part_anime , SsPartState* state );
 		void	updateInstance( int nowTime , SsPart* part , SsPartAnime* part_anime , SsPartState* state );
@@ -159,6 +161,9 @@ namespace spritestudio6
 		void setMaskParentSetting(bool flg);							//親のマスク対象を設定する
 		bool getMaskParentSetting(void) { return maskParentSetting; };	//設定された親のマスク対象を取得する
 
+		void  setCustomData(void* d) {custom_data=d;}
+		void* getCustomData(){ return custom_data;}
+		
 	};
 
 

--- a/Common/Animator/ssplayer_cellmap.cpp
+++ b/Common/Animator/ssplayer_cellmap.cpp
@@ -59,7 +59,10 @@ SsCelMapLinker::SsCelMapLinker(SsCellMap* cellmap, SsString filePath)
 		puts("SSTextureFactory not created yet.");
 		throw;
 	}
-
+#ifdef _NOTUSE_TEXTURE_FULLPATH
+	//スルー
+	SsString filePathFs = cellmap->imagePath;
+#else
 	std::string fullpath = getFullPath(filePath, path2dir(cellmap->imagePath));
 	fullpath = fullpath + path2file(cellmap->imagePath);
 	fullpath = nomarizeFilename(fullpath);
@@ -67,6 +70,7 @@ SsCelMapLinker::SsCelMapLinker(SsCellMap* cellmap, SsString filePath)
 //	DEBUG_PRINTF("TextureFile Load %s \n", fullpath.c_str());
 //	tex = SSTextureFactory::loadTexture(fullpath.c_str());
 	SsString filePathFs = SsCharConverter::convert_path_string( fullpath );
+#endif
 	DEBUG_PRINTF("TextureFile Load %s \n", filePathFs.c_str());
 	tex = SSTextureFactory::loadTexture(filePathFs.c_str());
 

--- a/Common/Animator/ssplayer_cellmap.cpp
+++ b/Common/Animator/ssplayer_cellmap.cpp
@@ -57,7 +57,9 @@ SsCelMapLinker::SsCelMapLinker(SsCellMap* cellmap, SsString filePath)
 	if (!SSTextureFactory::isExist())
 	{
 		puts("SSTextureFactory not created yet.");
+#ifndef _NOTUSE_EXCEPTION		
 		throw;
+#endif		
 	}
 #ifdef _NOTUSE_TEXTURE_FULLPATH
 	//スルー

--- a/Common/Animator/ssplayer_cellmap.h
+++ b/Common/Animator/ssplayer_cellmap.h
@@ -71,8 +71,6 @@ private:
 	SsString	CellMapPath;
 
 private:
-	void	addIndex(SsCellMap* cellmap);
-	void	addMap(SsCellMap* cellmap);
 
 public:
 	SsCellMapList(){}
@@ -111,6 +109,12 @@ public:
 	
 	bool preloadTexture(SsProject* proj);
 	bool unloadTexture(SsProject* proj = 0);
+
+	//インデックスで参照するために登録する
+	void addIndex(SsCellMap* cellmap);
+
+	//辞書で検索するために登録する関数
+	void addMap(SsCellMap* cellmap);
 
 };
 

--- a/Common/Animator/ssplayer_effect.cpp
+++ b/Common/Animator/ssplayer_effect.cpp
@@ -670,7 +670,7 @@ void	SsEffectRenderer::update(float delta)
 //------------------------------------------------------------------------------
 void	SsEffectRenderer::draw()
 {
-	SsCurrentRenderer::getRender()->renderSetup();					
+	SsCurrentRenderer::getRender()->renderSetup(0);					
 
 	int cnt = 0;
 

--- a/Common/Animator/ssplayer_effect2.cpp
+++ b/Common/Animator/ssplayer_effect2.cpp
@@ -537,7 +537,7 @@ void	SsEffectRenderV2::drawSprite(
 
 	//SsCellValue*			dispCell;
 
-	SsCurrentRenderer::getRender()->renderSetup();	
+	SsCurrentRenderer::getRender()->renderSetup(0);	
 
 	switch( blendType )
 	{

--- a/Common/Animator/ssplayer_render.h
+++ b/Common/Animator/ssplayer_render.h
@@ -10,12 +10,14 @@ namespace spritestudio6
 
 struct SsPartState;
 struct SsCellValue;
+class SsAnimeDecoder;
+
 
 class ISsRenderer
 {
 public:
 	virtual void	initialize() = 0;
-	virtual void	renderSetup() = 0;
+	virtual void	renderSetup(SsAnimeDecoder* state) = 0;
 	virtual void	renderPart(SsPartState* state) = 0;
 	virtual void	execMask(SsPartState* state) = 0;
 	virtual void	clearMask() = 0;
@@ -29,6 +31,7 @@ public:
 	virtual void	SetAlphaBlendMode(SsBlendType::_enum type)=0;
 	virtual void	SetTexture( SsCellValue* cell )=0;
 	virtual void	enableMask(bool flag) = 0;
+//	virtual void	renderMesh(SsMeshPart* mesh , float alpha );
 
 };
 

--- a/Common/Drawer/ssplayer_render_dx9.cpp
+++ b/Common/Drawer/ssplayer_render_dx9.cpp
@@ -63,7 +63,7 @@ void	SsRenderDX9::initialize()
 
 }
 
-void	SsRenderDX9::renderSetup()
+void	SsRenderDX9::renderSetup(SsAnimeDecoder* state)
 {
 
 }

--- a/Common/Drawer/ssplayer_render_dx9.h
+++ b/Common/Drawer/ssplayer_render_dx9.h
@@ -18,7 +18,7 @@ public:
 	virtual ~SsRenderDX9(){}
 
 	virtual void	initialize();
-	virtual void	renderSetup();
+	virtual void	renderSetup(SsAnimeDecoder* state);
 	virtual void	renderPart( SsPartState* state );
 
 	//未実装

--- a/Common/Drawer/ssplayer_render_gl.cpp
+++ b/Common/Drawer/ssplayer_render_gl.cpp
@@ -337,7 +337,7 @@ void	SsRenderGL::initialize()
 
 }
 
-void	SsRenderGL::renderSetup()
+void	SsRenderGL::renderSetup(SsAnimeDecoder* state)
 {
 	glDisableClientState( GL_COLOR_ARRAY );
 	glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE);

--- a/Common/Drawer/ssplayer_render_gl.h
+++ b/Common/Drawer/ssplayer_render_gl.h
@@ -21,9 +21,15 @@ public:
 
 	static void clearShaderCache();
 	virtual void	initialize();
-	virtual void	renderSetup();
+	virtual void	renderSetup(SsAnimeDecoder* state);
+
+	//通常アニメパーツ描画
 	virtual void	renderPart( SsPartState* state );
 
+	//メッシュパーツのレンダリング
+	virtual void	renderMesh(SsMeshPart* mesh, float alpha);
+
+	//effect用スプライト
 	virtual void	renderSpriteSimple( float matrix[16], 
 										int width, int height, 
 										SsVector2& pivot , 
@@ -36,8 +42,6 @@ public:
 	virtual void	clearMask();
 	virtual void	enableMask(bool flag);
 
-
-	virtual void	renderMesh(SsMeshPart* mesh, float alpha);
 
 
 

--- a/Common/Helper/DebugPrint.cpp
+++ b/Common/Helper/DebugPrint.cpp
@@ -45,7 +45,11 @@ void	THROW_ERROR_MESSAGE_MAIN( std::string str , char* fname , size_t line )
 	std::string ___err_message = ___str__buffer;
 
 	DEBUG_PRINTF( ___str__buffer );
+
+#ifndef _NOTUSE_EXCEPTION		
 	throw ThrowErrorMessage( 0 , ___err_message );
+#endif		
+
 }
 
 

--- a/Common/Helper/IsshTexture.cpp
+++ b/Common/Helper/IsshTexture.cpp
@@ -2,8 +2,9 @@
 #include "IsshTexture.h"
 #include "../Helper/DebugPrint.h"
 
+#ifndef _NOTUSE_STBI
 #include "stb_image.h"
-
+#endif
 
 namespace spritestudio6
 {
@@ -11,7 +12,11 @@ namespace spritestudio6
 
 static SSTextureLoader::DataHandle defaultLoadImageFromFile( const char* fileName, int* width, int* height, int* bpp )
 {
+#ifdef _NOTUSE_STBI
+	void* image = 0;
+#else
 	stbi_uc* image = stbi_load( fileName, width , height , bpp , 0 );
+#endif
 	if ( image == nullptr )
 	{	// エラー時処理
 		return SSTextureLoader::InvalidDataHandle;
@@ -23,12 +28,20 @@ static void defaultDecodeEndImageFile( SSTextureLoader::DataHandle handle )
 {
 	if ( handle != SSTextureLoader::InvalidDataHandle)
 	{
+#ifndef _NOTUSE_STBI
 		stbi_image_free( (void*)handle );
+#endif
 	}
 }
 static const char* defaultMessageGetFailureLoadFromFile()
 {
+#ifdef _NOTUSE_STBI
+	return 0;
+#else
 	return ( stbi_failure_reason() );
+
+#endif
+		
 }
 static bool defaultCheckSizePow2(int width, int height)
 {

--- a/Common/Helper/IsshTexture.h
+++ b/Common/Helper/IsshTexture.h
@@ -87,6 +87,7 @@ private:
 	static SSTextureFactory*	m_myInst;
 
 	std::map<SsString, ISSTexture*> textureCache;
+	bool auto_release_baseclass;
 
 
 private:
@@ -94,16 +95,20 @@ private:
 
 public:
 	SSTextureFactory(){}
-	SSTextureFactory(ISSTexture* texture_base_class)
+	SSTextureFactory(ISSTexture* texture_base_class , bool auto_release_baseclass = true)
 	{ 
 		m_myInst = this ; m_texture_base_class = texture_base_class;
+		this->auto_release_baseclass = auto_release_baseclass;
 	}
 
 	virtual ~SSTextureFactory()
 	{
-		if ( m_texture_base_class )
-			delete m_texture_base_class;
-		m_myInst = 0;
+		if (this->auto_release_baseclass)
+		{
+			if ( m_texture_base_class )
+				delete m_texture_base_class;
+			m_myInst = 0;
+		}
 	}
 
 	static bool	isExist(){ return m_myInst != 0; }

--- a/Common/Loader/ssloader_ssae.cpp
+++ b/Common/Loader/ssloader_ssae.cpp
@@ -3,6 +3,21 @@
 namespace spritestudio6
 {
 
+SsAnimePack*	ssloader_ssae::Parse(const char* xmlstr , size_t len)
+{
+	libXML::XMLDocument xml;
+
+	if ( libXML::XML_SUCCESS == xml.Parse(xmlstr,len) )
+	{
+		SsXmlIArchiver ar( xml.GetDocument() , "SpriteStudioAnimePack" );
+
+		SsAnimePack* animepack = new SsAnimePack();
+		animepack->__Serialize( &ar );
+		return animepack;
+	}
+
+
+}
 
 SsAnimePack*	ssloader_ssae::Load(const std::string& filename )
 {
@@ -21,6 +36,8 @@ SsAnimePack*	ssloader_ssae::Load(const std::string& filename )
 
 	return anime;
 }
+
+
 
 
 SsAnimation*	SsAnimePack::findAnimation(SsString& name)

--- a/Common/Loader/ssloader_ssae.h
+++ b/Common/Loader/ssloader_ssae.h
@@ -427,6 +427,7 @@ public:
 
 	///ssaeファイル名を指定しロードが成功したらそのSsAnimePackのポインタを返します。
 	static SsAnimePack*	Load(const std::string& filename );
+	static SsAnimePack*	Parse(const char* xmlstr , size_t len);
 
 };
 

--- a/Common/Loader/ssloader_ssce.cpp
+++ b/Common/Loader/ssloader_ssce.cpp
@@ -5,6 +5,32 @@
 namespace spritestudio6
 {
 
+
+SsCellMap*	ssloader_ssce::Parse(const char* xmlstr , size_t len, int* error)
+{
+	libXML::XMLDocument xml;
+
+	libXML::XMLError xmlerr = xml.Parse(xmlstr, len);
+
+	if ( libXML::XML_SUCCESS == xmlerr)
+	{
+		SsXmlIArchiver ar( xml.GetDocument() , "SpriteStudioCellMap" );
+
+		SsCellMap* cellmap = new SsCellMap();
+		cellmap->__Serialize( &ar );
+		return cellmap;
+	}
+	else {
+		if (error)
+		{
+			*error = xmlerr;
+		}
+	}
+
+	return 0;
+}
+
+
 SsCellMap*	ssloader_ssce::Load(const std::string& filename )
 {
 	SsString _basepath = "";

--- a/Common/Loader/ssloader_ssce.h
+++ b/Common/Loader/ssloader_ssce.h
@@ -133,6 +133,7 @@ public:
 	virtual ~ssloader_ssce(){}
 
 	static SsCellMap*	Load(const std::string& filename );
+	static SsCellMap*	Parse(const char* xmlstr , size_t len , int* error = 0);
 
 };
 

--- a/Common/Loader/ssloader_sspj.cpp
+++ b/Common/Loader/ssloader_sspj.cpp
@@ -142,6 +142,19 @@ SsSequence*		SsProject::findSequence( SsString& sequencePackName , SsString& Seq
 	return 0;
 }
 
+SsProject*	ssloader_sspj::Parse_ProjectOnly(const char* xmlstr , size_t len)
+{
+	libXML::XMLDocument xml;
+
+	if ( libXML::XML_SUCCESS == xml.Parse(xmlstr,len) )
+	{
+		SsXmlIArchiver ar( xml.GetDocument() , "SpriteStudioProject" );
+
+		SsProject* proj = new SsProject();
+		proj->__Serialize( &ar );
+		return proj;
+	}
+}
 
 SsProject*	ssloader_sspj::Load(const std::string& filename )
 {

--- a/Common/Loader/ssloader_sspj.h
+++ b/Common/Loader/ssloader_sspj.h
@@ -213,9 +213,15 @@ public:
 
 
 	///AnimePack(ssae)のファイル名をパス付きで取得する
-	SsString	getAnimePackFilePath( size_t index ) { 
+	SsString	getAnimePackFilePath( size_t index , bool add_basepath = true) { 
 		if ( animepackNames.size() <= index ) return "";
-		return getSsaeBasepath() + animepackNames[index];
+
+		if (add_basepath)
+		{
+			return getSsaeBasepath() + animepackNames[index];
+		}else{
+			return animepackNames[index];
+		}
 	}
 
 
@@ -223,7 +229,6 @@ public:
 	SsString	getCellMapFilePath( size_t index ) { 
 		if ( cellmapNames.size() <= index ) return "";
         SsString str = getSsceBasepath();
-
 
 		std::string f = cellmapNames[index];
 		

--- a/Common/Loader/ssloader_sspj.h
+++ b/Common/Loader/ssloader_sspj.h
@@ -262,8 +262,9 @@ private:
 public:
 	ssloader_sspj(){}
 	virtual ~ssloader_sspj(){}
+	
 	static SsProject*	Load(const std::string& filename );
-
+	static SsProject*	Parse_ProjectOnly(const char* xml , size_t len);
 };
 
 

--- a/Common/Loader/ssstring_uty.cpp
+++ b/Common/Loader/ssstring_uty.cpp
@@ -87,6 +87,7 @@ bool	is_digit_string( std::string &in_str , bool* is_priod )
 
 std::string getFullPath( const std::string& basePath , const std::string &relPath )
 {
+#ifndef _NOTUSE_TEXTURE_FULLPATH
 #ifdef _WIN32
 	char	curPath[_MAX_PATH];
 	char	buffer_[_MAX_PATH];
@@ -145,7 +146,9 @@ std::string getFullPath( const std::string& basePath , const std::string &relPat
     ret_temp+="/";
     return ret_temp;
 #endif
-
+#else
+	return relPath;
+#endif
 }
 std::string Replace( std::string String1, std::string String2, std::string String3 )
 {


### PR DESCRIPTION
- Godot対応のため、RenderとDecoder周りで外部オブジェクトの保持と値参照をできるようにした。
- また、SSPJのファイルロードの際にSSAE、SSCEなどを一括で読み込むユーティリティがあったが個別に読む関数を追加
- XMLのデータパースの際ファイルロードだけではなく、文字列からのパースに対応した。
- テクスチャロード時にフルパス生成を無効にするオプションを追加
- 

